### PR TITLE
Init2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dist
 .pnp.*
 
 dist/**/*
+/memory-bank

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2025] [Jincheng Zhang, MetaMCP, metamcp.com, https://github.com/metatool-ai/metatool-app]
+   Copyright [2025] [Jincheng Zhang, PluggedinMCP, plugged.in, https://github.com/VeriTeknik/pluggedin-app]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ PluggedinMCP MCP Server is a proxy server that joins multiple MCP⁠ servers int
 
 PluggedinMCP App repo: https://github.com/VeriTeknik/pluggedin-app
 
+## Key Features
+
+- **MCP Playground**: Interactive environment to test and experiment with your MCP tools
+- **Multi-Server Support**: Connect both STDIO (command-line) and SSE (HTTP-based) MCP servers
+- **Custom MCP Servers**: Create and manage your own Python-based MCP servers
+- **Multi-Workspace Layer**: Switch between different sets of MCP configurations with one click
+- **Namespace Isolation**: Keep joined MCPs separate and organized
+- **LLM Integration**: Seamless integration with OpenAI and Anthropic models
+- **Real-time Updates**: GUI dynamic updates of MCP configurations
+- **Universal Compatibility**: Works with any MCP client
+
 ## Installation
 
 ### Installing via Smithery
@@ -41,13 +52,6 @@ npx -y @pluggedin/pluggedin-mcp-proxy@latest
   }
 }
 ```
-
-## Highlights
-
-- Compatible with ANY MCP Client
-- Multi-Workspaces layer enables you to switch to another set of MCP configs within one-click.
-- GUI dynamic updates of MCP configs.
-- Namespace isolation for joined MCPs.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,41 @@
-# MetaMCP MCP Server
+# PluggedinMCP MCP Server
 
-[https://metamcp.com](https://metamcp.com): The One MCP to manage all your MCPs
+[https://plugged.in](https://plugged.in): The One MCP to manage all your MCPs
 
-MetaMCP MCP Server is a proxy server that joins multiple MCP⁠ servers into one. It fetches tool/prompt/resource configurations from MetaMCP App⁠ and routes tool/prompt/resource requests to the correct underlying server.
+PluggedinMCP MCP Server is a proxy server that joins multiple MCP⁠ servers into one. It fetches tool/prompt/resource configurations from PluggedinMCP App⁠ and routes tool/prompt/resource requests to the correct underlying server.
 
-[![smithery badge](https://smithery.ai/badge/@metatool-ai/mcp-server-metamcp)](https://smithery.ai/server/@metatool-ai/mcp-server-metamcp)
+[![smithery badge](https://smithery.ai/badge/@VeriTeknik/pluggedin-mcp-proxy)](https://smithery.ai/server/@VeriTeknik/pluggedin-mcp-proxy)
 
-<a href="https://glama.ai/mcp/servers/0po36lc7i6">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/0po36lc7i6/badge" alt="MetaServer MCP server" />
-</a>
 
-MetaMCP App repo: https://github.com/metatool-ai/metatool-app
+PluggedinMCP App repo: https://github.com/VeriTeknik/pluggedin-app
 
 ## Installation
 
 ### Installing via Smithery
 
-Sometimes Smithery works (confirmed in Windsurf locally) but sometimes it is unstable because MetaMCP is special that it runs other MCPs on top of it. Please consider using manual installation if it doesn't work instead.
+Sometimes Smithery works (confirmed in Windsurf locally) but sometimes it is unstable because PluggedinMCP is special that it runs other MCPs on top of it. Please consider using manual installation if it doesn't work instead.
 
-To install MetaMCP MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@metatool-ai/mcp-server-metamcp):
+To install PluggedinMCP MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@VeriTeknik/pluggedin-mcp-proxy):
 
 ```bash
-npx -y @smithery/cli install @metatool-ai/mcp-server-metamcp --client claude
+npx -y @smithery/cli install @VeriTeknik/pluggedin-mcp-proxy --client claude
 ```
 
 ### Manual Installation
 
 ```bash
-export METAMCP_API_KEY=<env>
-npx -y @metamcp/mcp-server-metamcp@latest
+export PLUGGEDIN_API_KEY=<env>
+npx -y @pluggedin/pluggedin-mcp-proxy@latest
 ```
 
 ```json
 {
   "mcpServers": {
-    "MetaMCP": {
+    "PluggedinMCP": {
       "command": "npx",
-      "args": ["-y", "@metamcp/mcp-server-metamcp@latest"],
+      "args": ["-y", "@pluggedin/pluggedin-mcp-proxy@latest"],
       "env": {
-        "METAMCP_API_KEY": "<your api key>"
+        "PLUGGEDIN_API_KEY": "<your api key>"
       }
     }
   }
@@ -54,21 +51,21 @@ npx -y @metamcp/mcp-server-metamcp@latest
 
 ## Environment Variables
 
-- METAMCP_API_KEY: Required. Obtained from MetaMCP App's "API Keys" page (https://metamcp.com/api-keys).
-- METAMCP_API_BASE_URL: Optional override for MetaMCP App URL (e.g. http://localhost:12005).
+- PLUGGEDIN_API_KEY: Required. Obtained from PluggedinMCP App's "API Keys" page (https://plugged.in/api-keys).
+- PLUGGEDIN_API_BASE_URL: Optional override for PluggedinMCP App URL (e.g. http://localhost:12005).
 
 ## Command Line Arguments
 
 You can configure the API key and base URL using command line arguments:
 
 ```bash
-npx -y @metamcp/mcp-server-metamcp@latest --metamcp-api-key <your-api-key> --metamcp-api-base-url <base-url>
+npx -y @pluggedin/pluggedin-mcp-proxy@latest --pluggedin-api-key <your-api-key> --pluggedin-api-base-url <base-url>
 ```
 
 For help with all available options:
 
 ```bash
-npx -y @metamcp/mcp-server-metamcp@latest --help
+npx -y @pluggedin/pluggedin-mcp-proxy@latest --help
 ```
 
 These command line arguments take precedence over environment variables.
@@ -78,28 +75,28 @@ These command line arguments take precedence over environment variables.
 ```mermaid
 sequenceDiagram
     participant MCPClient as MCP Client (e.g. Claude Desktop)
-    participant MetaMCP-mcp-server as MetaMCP MCP Server
-    participant MetaMCPApp as MetaMCP App
-    participant MCPServers as Installed MCP Servers in Metatool App
+    participant PluggedinMCP-mcp-server as PluggedinMCP MCP Server
+    participant PluggedinMCPApp as PluggedinMCP App
+    participant MCPServers as Installed MCP Servers in Plugged.in App
 
-    MCPClient ->> MetaMCP-mcp-server: Request list tools
-    MetaMCP-mcp-server ->> MetaMCPApp: Get tools configuration & status
-    MetaMCPApp ->> MetaMCP-mcp-server: Return tools configuration & status
+    MCPClient ->> PluggedinMCP-mcp-server: Request list tools
+    PluggedinMCP-mcp-server ->> PluggedinMCPApp: Get tools configuration & status
+    PluggedinMCPApp ->> PluggedinMCP-mcp-server: Return tools configuration & status
 
     loop For each listed MCP Server
-        MetaMCP-mcp-server ->> MCPServers: Request list_tools
-        MCPServers ->> MetaMCP-mcp-server: Return list of tools
+        PluggedinMCP-mcp-server ->> MCPServers: Request list_tools
+        MCPServers ->> PluggedinMCP-mcp-server: Return list of tools
     end
 
-    MetaMCP-mcp-server ->> MetaMCP-mcp-server: Aggregate tool lists
-    MetaMCP-mcp-server ->> MCPClient: Return aggregated list of tools
+    PluggedinMCP-mcp-server ->> PluggedinMCP-mcp-server: Aggregate tool lists
+    PluggedinMCP-mcp-server ->> MCPClient: Return aggregated list of tools
 
-    MCPClient ->> MetaMCP-mcp-server: Call tool
-    MetaMCP-mcp-server ->> MCPServers: call_tool to target MCP Server
-    MCPServers ->> MetaMCP-mcp-server: Return tool response
-    MetaMCP-mcp-server ->> MCPClient: Return tool response
+    MCPClient ->> PluggedinMCP-mcp-server: Call tool
+    PluggedinMCP-mcp-server ->> MCPServers: call_tool to target MCP Server
+    MCPServers ->> PluggedinMCP-mcp-server: Return tool response
+    PluggedinMCP-mcp-server ->> MCPClient: Return tool response
 ```
 
 ## Credits
-
+- Forked from https://github.com/metatool-ai/mcp-server-metamcp
 - Inspirations and some code (refactored in this project) from https://github.com/adamwattis/mcp-proxy-server/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ services:
       - NODE_ENV=production
     restart: unless-stopped
     # Add any additional environment variables or command arguments here
-    # command: --metamcp-api-key your-api-key --metamcp-api-base-url your-base-url
+    # command: --pluggedin-api-key your-api-key --pluggedin-api-base-url your-base-url

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@metamcp/mcp-server-metamcp",
+  "name": "@pluggedin/pluggedin-mcp-proxy",
   "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@metamcp/mcp-server-metamcp",
+      "name": "@pluggedin/pluggedin-mcp-proxy",
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15,7 +15,7 @@
         "zod": "^3.24.2"
       },
       "bin": {
-        "mcp-server-metamcp": "dist/index.js"
+        "pluggedin-mcp-proxy": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.13.4",

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@metamcp/mcp-server-metamcp",
+  "name": "@pluggedin/pluggedin-mcp-proxy",
   "version": "0.4.0",
-  "description": "MCP Server MetaMCP manages all your other MCPs in one MCP.",
+  "description": "MCP Server PluggedinMCP manages all your other MCPs in one MCP.",
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
     "watch": "tsc --watch",
-    "inspector": "dotenv -e .env.local npx @modelcontextprotocol/inspector dist/index.js -e METAMCP_API_KEY=${METAMCP_API_KEY} -e METAMCP_API_BASE_URL=${METAMCP_API_BASE_URL}",
-    "inspector:prod": "dotenv -e .env.production.local npx @modelcontextprotocol/inspector dist/index.js -e METAMCP_API_KEY=${METAMCP_API_KEY}",
+    "inspector": "dotenv -e .env.local npx @modelcontextprotocol/inspector dist/index.js -e PLUGGEDIN_API_KEY=${PLUGGEDIN_API_KEY} -e PLUGGEDIN_API_BASE_URL=${PLUGGEDIN_API_BASE_URL}",
+    "inspector:prod": "dotenv -e .env.production.local npx @modelcontextprotocol/inspector dist/index.js -e PLUGGEDIN_API_KEY=${PLUGGEDIN_API_KEY}",
     "report": "dotenv -e .env.local -- node dist/index.js --report"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/metatool-ai/mcp-server-metamcp.git"
+    "url": "git+https://github.com/VeriTeknik/pluggedin-mcp-proxy.git"
   },
   "author": "James Zhang",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/metatool-ai/mcp-server-metamcp/issues"
+    "url": "https://github.com/VeriTeknik/pluggedin-mcp-proxy/issues"
   },
-  "homepage": "https://github.com/metatool-ai/mcp-server-metamcp#readme",
+  "homepage": "https://github.com/VeriTeknik/pluggedin-mcp-proxy#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.5.0",
     "axios": "^1.7.9",
@@ -33,7 +33,7 @@
   },
   "type": "module",
   "bin": {
-    "mcp-server-metamcp": "dist/index.js"
+    "pluggedin-mcp-proxy": "dist/index.js"
   },
   "files": [
     "dist"

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,17 +6,17 @@ startCommand:
     # JSON Schema defining the configuration options for the MCP.
     type: object
     required:
-      - metamcpApiKey
+      - pluggedinApiKey
     properties:
-      metamcpApiKey:
+      pluggedinApiKey:
         type: string
-        description: The API key from metamcp.com/api-keys. Required.
-      metamcpApiBaseUrl:
+        description: The API key from plugged.in/api-keys. Required.
+      pluggedinApiBaseUrl:
         type: string
-        description: Optional override for the MetaMCP App URL (default is https://api.metamcp.com).
+        description: Optional override for the PluggedinMCP App URL (default is https://plugged.in/api/).
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     # Note: Command line arguments can also be used directly:
-    # --metamcp-api-key <your-api-key> --metamcp-api-base-url <base-url>
+    # --pluggedin-api-key <your-api-key> --pluggedin-api-base-url <base-url>
     |-
-    (config) => ({ command: 'node', args: ['dist/index.js'], env: { METAMCP_API_KEY: config.metamcpApiKey, ...(config.metamcpApiBaseUrl && { METAMCP_API_BASE_URL: config.metamcpApiBaseUrl }) } })
+    (config) => ({ command: 'node', args: ['dist/index.js'], env: { PLUGGEDIN_API_KEY: config.pluggedinApiKey, ...(config.pluggedinApiBaseUrl && { PLUGGEDIN_API_BASE_URL: config.pluggedinApiBaseUrl }) } })

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,7 +5,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { ServerParameters } from "./fetch-metamcp.js";
+import { ServerParameters } from "./fetch-pluggedinmcp.js";
 
 const sleep = (time: number) =>
   new Promise<void>((resolve) => setTimeout(() => resolve(), time));
@@ -14,7 +14,7 @@ export interface ConnectedClient {
   cleanup: () => Promise<void>;
 }
 
-export const createMetaMcpClient = (
+export const createPluggedinMCPClient = (
   serverParams: ServerParameters
 ): { client: Client | undefined; transport: Transport | undefined } => {
   let transport: Transport | undefined;
@@ -39,7 +39,7 @@ export const createMetaMcpClient = (
 
   const client = new Client(
     {
-      name: "MetaMCP",
+      name: "PluggedinMCP",
       version: "0.4.0",
     },
     {
@@ -53,7 +53,7 @@ export const createMetaMcpClient = (
   return { client, transport };
 };
 
-export const connectMetaMcpClient = async (
+export const connectPluggedinMCPClient = async (
   client: Client,
   transport: Transport
 ): Promise<ConnectedClient | undefined> => {

--- a/src/fetch-capabilities.ts
+++ b/src/fetch-capabilities.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
+import { getPluggedinMCPApiBaseUrl, getPluggedinMCPApiKey } from "./utils.js";
 
 export enum ProfileCapability {
   TOOLS_MANAGEMENT = "TOOLS_MANAGEMENT",
@@ -26,12 +26,12 @@ export async function getProfileCapabilities(
   }
 
   try {
-    const apiKey = getMetaMcpApiKey();
-    const apiBaseUrl = getMetaMcpApiBaseUrl();
+    const apiKey = getPluggedinMCPApiKey();
+    const apiBaseUrl = getPluggedinMCPApiBaseUrl();
 
     if (!apiKey) {
       console.error(
-        "METAMCP_API_KEY is not set. Please set it via environment variable or command line argument."
+        "PLUGGEDIN_API_KEY is not set. Please set it via environment variable or command line argument."
       );
       return _capabilitiesCache || [];
     }

--- a/src/fetch-pluggedinmcp.ts
+++ b/src/fetch-pluggedinmcp.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
 import {
   getDefaultEnvironment,
-  getMetaMcpApiBaseUrl,
-  getMetaMcpApiKey,
+  getPluggedinMCPApiBaseUrl,
+  getPluggedinMCPApiKey,
 } from "./utils.js";
 
 // Define a new interface for server parameters that can be either STDIO or SSE
@@ -38,12 +38,12 @@ export async function getMcpServers(
   }
 
   try {
-    const apiKey = getMetaMcpApiKey();
-    const apiBaseUrl = getMetaMcpApiBaseUrl();
+    const apiKey = getPluggedinMCPApiKey();
+    const apiBaseUrl = getPluggedinMCPApiBaseUrl();
 
     if (!apiKey) {
       console.error(
-        "METAMCP_API_KEY is not set. Please set it via environment variable or command line argument."
+        "PLUGGEDIN_API_KEY is not set. Please set it via environment variable or command line argument."
       );
       return _mcpServersCache || {};
     }

--- a/src/fetch-tools.ts
+++ b/src/fetch-tools.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
+import { getPluggedinMCPApiBaseUrl, getPluggedinMCPApiKey } from "./utils.js";
 
 enum ToolStatus {
   ACTIVE = "ACTIVE",
@@ -31,12 +31,12 @@ export async function getInactiveTools(
   }
 
   try {
-    const apiKey = getMetaMcpApiKey();
-    const apiBaseUrl = getMetaMcpApiBaseUrl();
+    const apiKey = getPluggedinMCPApiKey();
+    const apiBaseUrl = getPluggedinMCPApiBaseUrl();
 
     if (!apiKey) {
       console.error(
-        "METAMCP_API_KEY is not set. Please set it via environment variable or command line argument."
+        "PLUGGEDIN_API_KEY is not set. Please set it via environment variable or command line argument."
       );
       return _toolsCache || {};
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,30 +9,30 @@ import { cleanupAllSessions } from "./sessions.js";
 const program = new Command();
 
 program
-  .name("mcp-server-metamcp")
-  .description("MetaMCP MCP Server - The One MCP to manage all your MCPs")
+  .name("pluggedin-mcp-proxy")
+  .description("PluggedinMCP MCP Server - The One MCP to manage all your MCPs")
   .option(
-    "--metamcp-api-key <key>",
-    "API key for MetaMCP (can also be set via METAMCP_API_KEY env var)"
+    "--pluggedin-api-key <key>",
+    "API key for PluggedinMCP (can also be set via PLUGGEDIN_API_KEY env var)"
   )
   .option(
-    "--metamcp-api-base-url <url>",
-    "Base URL for MetaMCP API (can also be set via METAMCP_API_BASE_URL env var)"
+    "--pluggedin-api-base-url <url>",
+    "Base URL for PluggedinMCP API (can also be set via PLUGGEDIN_API_BASE_URL env var)"
   )
   .option(
     "--report",
-    "Fetch all MCPs, initialize clients, and report tools to MetaMCP API"
+    "Fetch all MCPs, initialize clients, and report tools to PluggedinMCP API"
   )
   .parse(process.argv);
 
 const options = program.opts();
 
 // Set environment variables from command line arguments
-if (options.metamcpApiKey) {
-  process.env.METAMCP_API_KEY = options.metamcpApiKey;
+if (options.pluggedinApiKey) {
+  process.env.PLUGGEDIN_API_KEY = options.pluggedinApiKey;
 }
-if (options.metamcpApiBaseUrl) {
-  process.env.METAMCP_API_BASE_URL = options.metamcpApiBaseUrl;
+if (options.pluggedinApiBaseUrl) {
+  process.env.PLUGGEDIN_API_BASE_URL = options.pluggedinApiBaseUrl;
 }
 
 async function main() {

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -18,11 +18,11 @@ import {
   GetPromptResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { getMcpServers } from "./fetch-metamcp.js";
+import { getMcpServers } from "./fetch-pluggedinmcp.js";
 import { getSessionKey, sanitizeName } from "./utils.js";
 import { cleanupAllSessions, getSession, initSessions } from "./sessions.js";
 import { ConnectedClient } from "./client.js";
-import { reportToolsToMetaMcp } from "./report-tools.js";
+import { reportToolsToPluggedinMCP } from "./report-tools.js";
 import { getInactiveTools, ToolParameters } from "./fetch-tools.js";
 import {
   getProfileCapabilities,
@@ -37,7 +37,7 @@ const inactiveToolsMap: Record<string, boolean> = {};
 export const createServer = async () => {
   const server = new Server(
     {
-      name: "MetaMCP",
+      name: "PluggedinMCP",
       version: "0.4.0",
     },
     {
@@ -126,7 +126,7 @@ export const createServer = async () => {
             });
 
             // Report full tools for this server
-            reportToolsToMetaMcp(
+            reportToolsToPluggedinMCP(
               result.tools.map((tool) => ({
                 name: tool.name,
                 description: tool.description,

--- a/src/report-tools.ts
+++ b/src/report-tools.ts
@@ -1,23 +1,23 @@
 import axios from "axios";
-import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
-import { getMcpServers } from "./fetch-metamcp.js";
+import { getPluggedinMCPApiBaseUrl, getPluggedinMCPApiKey } from "./utils.js";
+import { getMcpServers } from "./fetch-pluggedinmcp.js";
 import { initSessions, getSession } from "./sessions.js";
 import { getSessionKey } from "./utils.js";
 import { ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
 
 // Define interface for tool data structure
-export interface MetaMcpTool {
+export interface PluggedinMCPTool {
   name: string;
   description?: string;
   toolSchema: any;
   mcp_server_uuid: string;
 }
 
-// API route handler for submitting tools to MetaMCP
-export async function reportToolsToMetaMcp(tools: MetaMcpTool[]) {
+// API route handler for submitting tools to PluggedinMCP
+export async function reportToolsToPluggedinMCP(tools: PluggedinMCPTool[]) {
   try {
-    const apiKey = getMetaMcpApiKey();
-    const apiBaseUrl = getMetaMcpApiBaseUrl();
+    const apiKey = getPluggedinMCPApiKey();
+    const apiBaseUrl = getPluggedinMCPApiBaseUrl();
 
     if (!apiKey) {
       return { error: "API key not set" };
@@ -56,7 +56,7 @@ export async function reportToolsToMetaMcp(tools: MetaMcpTool[]) {
       });
     }
 
-    // Submit valid tools to MetaMCP API
+    // Submit valid tools to PluggedinMCP API
     let results: any[] = [];
     if (validTools.length > 0) {
       try {
@@ -111,7 +111,7 @@ export async function reportToolsToMetaMcp(tools: MetaMcpTool[]) {
   }
 }
 
-// Function to fetch all MCP servers, initialize clients, and report tools to MetaMCP API
+// Function to fetch all MCP servers, initialize clients, and report tools to PluggedinMCP API
 export async function reportAllTools() {
   console.log("Fetching all MCPs and initializing clients...");
 
@@ -150,10 +150,10 @@ export async function reportAllTools() {
 
         if (result.tools && result.tools.length > 0) {
           console.log(
-            `Reporting ${result.tools.length} tools from ${params.name} to MetaMCP API...`
+            `Reporting ${result.tools.length} tools from ${params.name} to PluggedinMCP API...`
           );
 
-          const reportResult = await reportToolsToMetaMcp(
+          const reportResult = await reportToolsToPluggedinMCP(
             result.tools.map((tool) => ({
               name: tool.name,
               description: tool.description,
@@ -174,6 +174,6 @@ export async function reportAllTools() {
     })
   );
 
-  console.log("Finished reporting all tools to MetaMCP API");
+  console.log("Finished reporting all tools to PluggedinMCP API");
   process.exit(0);
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,8 +1,8 @@
-import { getMcpServers, ServerParameters } from "./fetch-metamcp.js";
+import { getMcpServers, ServerParameters } from "./fetch-pluggedinmcp.js";
 import {
   ConnectedClient,
-  createMetaMcpClient,
-  connectMetaMcpClient,
+  createPluggedinMCPClient,
+  connectPluggedinMCPClient,
 } from "./client.js";
 import { getSessionKey } from "./utils.js";
 
@@ -28,12 +28,12 @@ export const getSession = async (
       })
     );
 
-    const { client, transport } = createMetaMcpClient(params);
+    const { client, transport } = createPluggedinMCPClient(params);
     if (!client || !transport) {
       return;
     }
 
-    const newClient = await connectMetaMcpClient(client, transport);
+    const newClient = await connectPluggedinMCPClient(client, transport);
     if (!newClient) {
       return;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { ServerParameters } from "./fetch-metamcp.js";
+import { ServerParameters } from "./fetch-pluggedinmcp.js";
 import crypto from "crypto";
 
 /**
@@ -46,17 +46,17 @@ export function getDefaultEnvironment(): Record<string, string> {
 }
 
 /**
- * Get the MetaMCP API base URL from environment variables
+ * Get the PluggedinMCP API base URL from environment variables
  */
-export function getMetaMcpApiBaseUrl(): string {
-  return process.env.METAMCP_API_BASE_URL || "https://api.metamcp.com";
+export function getPluggedinMCPApiBaseUrl(): string {
+  return process.env.PLUGGEDIN_API_BASE_URL || "https://plugged.in/";
 }
 
 /**
- * Get the MetaMCP API key from environment variables
+ * Get the PluggedinMCP API key from environment variables
  */
-export function getMetaMcpApiKey(): string | undefined {
-  return process.env.METAMCP_API_KEY;
+export function getPluggedinMCPApiKey(): string | undefined {
+  return process.env.PLUGGEDIN_API_KEY;
 }
 
 export function sanitizeName(name: string): string {


### PR DESCRIPTION
## Summary by Sourcery

Rebrand the MCP server from MetaMCP to PluggedinMCP, updating all references, configuration, and documentation to reflect the new project name and associated URLs.

New Features:
- Added a comprehensive list of key features in the README, including MCP Playground, Multi-Server Support, Custom MCP Servers, and LLM Integration

Documentation:
- Updated README with new project name, website, and expanded feature descriptions
- Updated installation and configuration instructions to use new project name and URLs

Chores:
- Forked the original project from metatool-ai/mcp-server-metamcp
- Updated all project references from MetaMCP to PluggedinMCP