### PR TITLE
feat: Auto-inject custom instructions via tool metadata

### DIFF
--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -69,6 +69,7 @@ import {
   updateDocumentStaticTool
 } from "./tools/static-tools.js";
 import { StaticToolHandlers } from "./handlers/static-handlers.js";
+import { formatCustomInstructionsForDiscovery } from "./utils/custom-instructions.js";
 import { 
   parsePrefixedToolName as parseAnyPrefixedToolName,
   isValidUuid
@@ -572,6 +573,9 @@ export const createServer = async () => {
                             });
                         }
 
+                        // Add custom instructions section
+                        dataContent += await formatCustomInstructionsForDiscovery();
+
                         // Log successful cache hit
                         logMcpActivity({
                             action: 'tool_call',
@@ -749,6 +753,9 @@ export const createServer = async () => {
                                 });
                                 forceRefreshContent += `\n`;
                             }
+                            
+                            // Add custom instructions section
+                            forceRefreshContent += await formatCustomInstructionsForDiscovery();
                             
                             forceRefreshContent += `📝 **Note**: Fresh discovery is running in background. Call pluggedin_discover_tools() again in 10-30 seconds to see if any new tools were discovered.`;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,9 @@ export interface ServerParameters {
     tokenUrl?: string;
     scopes?: string[];
   }; // OAuth configuration for authorization code flow
+  // Custom instructions from API
+  customInstructions?: string;
+  customInstructionsDescription?: string;
   // Add other relevant fields fetched from the API if needed
 }
 


### PR DESCRIPTION
- Removed custom instructions from prompts list (no more __system_context prompts)
- Added custom instructions to tool metadata for each tool
- Instructions are fetched from getMcpServers() and added to tool.metadata
- Created helper utilities for managing custom instructions
- Added constraint validation for read-only and other restrictions
- Custom contexts are now automatically available to AI assistants

## Summary by Sourcery

Auto-inject custom server-specific instructions into tool metadata and enforce their constraints during tool invocation, replacing the previous prompts-based approach.

New Features:
- Auto-inject custom instructions from MCP server configurations into each tool’s metadata
- Enforce instruction-derived constraints (read-only, no-delete, no-update, etc.) on tool calls at runtime

Enhancements:
- Remove custom instructions from the prompts API and only fetch standard prompts
- Augment proxied tool call requests with serverContext metadata
- Extend static handlers to build, store, and expose server context (instructions and constraints) during setup and discovery processes
- Introduce a helper utilities module for extracting, formatting, and validating custom instructions and constraints