### PR TITLE
 - Add support for custom headers and session ID in StreamableHTTP tr…

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { ServerParameters } from "./types.js";
 import { createRequire } from 'module';
-import { debugError } from './debug-log.js';
+import { debugLog, debugError } from './debug-log.js';
 // import { container } from './di-container.js'; // Removed DI container
 // import { Logger } from './logging.js'; // Removed Logger type
 
@@ -106,11 +106,13 @@ export const createPluggedinMCPClient = (
       // Add headers if provided
       if (serverParams.headers) {
         transportOptions.requestInit.headers = serverParams.headers;
+        debugLog(`[MCP] StreamableHTTP transport: Adding ${Object.keys(serverParams.headers).length} custom headers for ${serverParams.name}`);
       }
       
       // Add session ID if provided
       if (serverParams.sessionId) {
         transportOptions.sessionId = serverParams.sessionId;
+        debugLog(`[MCP] StreamableHTTP transport: Using session ID for ${serverParams.name}`);
       }
       
       // Add OAuth configuration if provided
@@ -138,7 +140,7 @@ export const createPluggedinMCPClient = (
             debugError(`OAuth authorization required for ${serverParams.name}`);
             throw new Error("OAuth authorization required - please authorize through the UI");
           },
-          refresh: async (refreshToken: string) => {
+          refresh: async (_refreshToken: string) => {
             // Implement token refresh if supported by the provider
             debugError(`OAuth token refresh not implemented for ${serverParams.name}`);
             throw new Error("Token refresh not implemented");

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,11 @@ export interface ServerParameters {
   // Custom instructions from API
   customInstructions?: string;
   customInstructionsDescription?: string;
+  // StreamableHTTP options (from pluggedin-app encrypted storage)
+  streamableHTTPOptions?: {
+    headers?: Record<string, string>;
+    sessionId?: string;
+  };
   // Add other relevant fields fetched from the API if needed
 }
 


### PR DESCRIPTION
…ansport

 - Map streamableHTTPOptions from API response to transport configuration
 - Add debug logging for header and session ID usage
 - Update types to include streamableHTTPOptions field
 - Use debugLog/debugError functions instead of console methods to prevent STDIO interference

 This enables StreamableHTTP MCP servers to authenticate and maintain stateful connections
 by passing headers and session IDs from the pluggedin-app encrypted storage.

## Summary by Sourcery

Enable stateful StreamableHTTP connections by passing custom headers and session IDs from the API into the transport layer, with added debug logging and standardized logging functions.

New Features:
- Support custom headers and session IDs for StreamableHTTP MCP servers and transports

Enhancements:
- Map streamableHTTPOptions from API response into headers and sessionId in configuration
- Log inclusion of headers and session ID for StreamableHTTP servers and client transports
- Replace console methods with debugLog and debugError to avoid STDIO interference
- Update types to include streamableHTTPOptions in ServerParameters
- Rename unused OAuth refreshToken parameter to _refreshToken to satisfy lint rules