### PR TITLE
feat: Add clipboard source tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pluggedin/pluggedin-mcp-proxy",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Unified MCP proxy that aggregates all your MCP servers (STDIO, SSE, Streamable HTTP) into one powerful interface. Access any tool through a single connection, search across unified documents with built-in RAG, and receive notifications from any model. Test your MCPs instantly in the playground with Claude, Gemini, OpenAI, and xAI. Perfect for Smithery deployment and all MCP clients. Features real-time activity logging, custom notifications with email delivery, and seamless profile-based workspace switching.",
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",

--- a/src/handlers/static-handlers.ts
+++ b/src/handlers/static-handlers.ts
@@ -27,7 +27,8 @@ import {
   ClipboardListInputSchema,
   ClipboardPushInputSchema,
   ClipboardPopInputSchema,
-  ClipboardEntry
+  ClipboardEntry,
+  MCP_CLIPBOARD_SOURCE
 } from '../schemas/index.js';
 import { getMcpServers } from "../fetch-pluggedinmcp.js";
 import { 
@@ -1353,7 +1354,7 @@ Set environment variables in your terminal before launching the editor.
         clipboardApiUrl,
         {
           ...validatedArgs,
-          source: 'mcp', // Hardcoded: MCP proxy always uses 'mcp' source
+          source: MCP_CLIPBOARD_SOURCE,
         },
         {
           headers: {
@@ -1730,7 +1731,7 @@ Set environment variables in your terminal before launching the editor.
         clipboardApiUrl,
         {
           ...validatedArgs,
-          source: 'mcp', // Hardcoded: MCP proxy always uses 'mcp' source
+          source: MCP_CLIPBOARD_SOURCE,
         },
         {
           headers: {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -219,6 +219,13 @@ export const UpdateDocumentInputSchema = z.object({
 // MIME type regex pattern for validation (prevents injection of special characters)
 const MIME_TYPE_REGEX = /^[\w.-]+\/[\w.+-]+$/;
 
+/** Clipboard source types */
+export const CLIPBOARD_SOURCES = ['ui', 'sdk', 'mcp'] as const;
+export type ClipboardSource = (typeof CLIPBOARD_SOURCES)[number];
+
+/** Source used by MCP proxy when writing clipboard entries */
+export const MCP_CLIPBOARD_SOURCE: ClipboardSource = 'mcp';
+
 /**
  * ClipboardEntry interface for type-safe response handling
  * Used to eliminate `any` types in response processing
@@ -234,7 +241,7 @@ export interface ClipboardEntry {
   visibility: string;
   createdByTool: string | null;
   createdByModel: string | null;
-  source: 'ui' | 'sdk' | 'mcp';
+  source: ClipboardSource;
   createdAt: string;
   updatedAt: string;
   expiresAt: string | null;


### PR DESCRIPTION
- Update clipboard schemas to include source field
- Hardcode source as 'mcp' for all clipboard operations

## Summary by Sourcery

Track clipboard source in the MCP proxy and schema.

New Features:
- Add a clipboard entry source field to distinguish between UI, SDK, and MCP origins.
- Populate clipboard requests from the MCP proxy with a hardcoded 'mcp' source.