### PR TITLE
fix(docker): build with pnpm so prod image receives security overrides

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,9 @@ jest.config.js
 # tsconfig.json is needed for the build step inside Docker
 # tsconfig.json
 .env*
-# package-lock.json # Keep for npm ci in Dockerfile
+# pnpm-lock.yaml and pnpm-workspace.yaml are required by the Docker build
+# (pnpm install --frozen-lockfile), so they must NOT be ignored here.
+package-lock.json
 yarn.lock
 .clinerules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,42 @@ FROM node:20-slim AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Enable pnpm via corepack, pinned to the version in package.json "packageManager".
+# We use pnpm (not npm) so that the security overrides in pnpm-workspace.yaml are
+# applied to the dependency tree — npm ignores pnpm overrides entirely.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
 
-# Install all dependencies (including dev dependencies for building)
-RUN npm ci
+# Copy manifest + lockfile + workspace config. pnpm-workspace.yaml holds the
+# dependency `overrides`; it MUST be present or --frozen-lockfile fails with a
+# lockfile/config mismatch.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Install all dependencies (including dev dependencies for building).
+# --frozen-lockfile ensures the build matches the committed lockfile exactly.
+RUN pnpm install --frozen-lockfile
 
 # Copy source code
 COPY . .
 
 # Build the application
-RUN npm run build
+RUN pnpm run build
 
 # Production stage
 FROM node:20-slim
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Enable pnpm via corepack (pinned through "packageManager" in package.json)
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
 
-# Install only production dependencies
-RUN npm ci --only=production
+# Copy manifest + lockfile + workspace config (overrides live in the workspace file)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Install only production dependencies. Overrides in pnpm-workspace.yaml are
+# applied here, so the production image receives the patched transitive versions.
+RUN pnpm install --frozen-lockfile --prod
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Problem

The `Dockerfile` built with `npm ci`, but:
- the repo only ships `pnpm-lock.yaml` (no `package-lock.json`), so `npm ci` had **no lockfile to honor**, and
- **npm ignores pnpm overrides entirely**, so the production image was built **without the Dependabot security pins** (hono, qs, follow-redirects, ip-address, postcss, …) that #69 added.

Net effect: the security work in v2.3.0 only protected dev installs; the published Docker image could still ship vulnerable transitive versions.

## Fix

Switch both build stages to **pnpm via corepack** (pinned through `package.json`'s `packageManager: pnpm@11.5.1`):
- Copy `package.json` + `pnpm-lock.yaml` + **`pnpm-workspace.yaml`** (the `overrides` live in the workspace file — it must be present or `--frozen-lockfile` fails with a lockfile/config mismatch).
- Builder: `pnpm install --frozen-lockfile` → `pnpm run build`.
- Production: `pnpm install --frozen-lockfile --prod`.
- `.dockerignore`: removed the stale "keep for npm ci" note (pnpm lock/workspace files are intentionally not ignored).

## Verification

Docker isn't available in my environment, so I could not run the image build itself. I did validate the critical logic in a clean pnpm store (mimicking a fresh Docker layer):

```
pnpm install --frozen-lockfile --prod   # exit 0, devDependencies skipped
# pinned transitive versions present in the prod tree:
hono = 4.12.23   qs = 6.15.2   follow-redirects = 1.16.0   ip-address = 10.2.0
```

So the production image now receives the patched versions. **Please run a real `docker build` in CI / locally to confirm corepack + the multi-stage build before merging.**

## Summary by Sourcery

Switch Docker image build to use pnpm with corepack so production images honor the workspace dependency overrides and lockfile.

Bug Fixes:
- Ensure Docker production builds receive the security-pinned dependency versions defined in the pnpm workspace overrides.

Enhancements:
- Standardize both Docker build stages on pnpm with frozen lockfile installs using corepack.
- Include pnpm lockfile and workspace configuration in Docker build context to keep container dependencies in sync with the repository configuration.