### PR TITLE
fix(docker): Node 24 + pnpm cooldown exclude so the image actually builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage
-FROM node:20-slim AS builder
+# Node 24: pnpm 11 (pinned via packageManager) requires a newer Node than 20,
+# which fails with ERR_UNKNOWN_BUILTIN_MODULE. Node 24 still bundles corepack.
+FROM node:24-slim AS builder
 
 WORKDIR /app
 
@@ -25,7 +27,7 @@ COPY . .
 RUN pnpm run build
 
 # Production stage
-FROM node:20-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,11 @@ onlyBuiltDependencies:
 
 allowBuilds:
   esbuild: true
+
+# Supply-chain cooldown (pnpm's default minimumReleaseAge) exclusion.
+# axios 1.17.0 was pulled deliberately to patch security advisories and is newer
+# than the cooldown window, which would otherwise block frozen installs (e.g. the
+# Docker build). The exclusion is scoped to this exact version and becomes a
+# no-op once it ages past the cooldown; the policy stays active for everything else.
+minimumReleaseAgeExclude:
+  - axios@1.17.0


### PR DESCRIPTION
Follow-up to #70. A real `docker build` (now possible with Docker installed) surfaced two breakages in the pnpm-based Dockerfile that the pnpm-level verification couldn't catch:

1. **`ERR_UNKNOWN_BUILTIN_MODULE`** — pnpm 11.5.1 (pinned via `packageManager`) crashes on `node:20-slim`; it relies on a Node builtin only present in newer Node. → Bumped both stages to **`node:24-slim`** (still bundles corepack; app `engines.node` is `>=18`).
2. **`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`** — pnpm 11.5.1's default supply-chain cooldown rejected `axios@1.17.0` (published within the cooldown window) during `pnpm install --frozen-lockfile`. → Added a scoped `minimumReleaseAgeExclude` for `axios@1.17.0` in `pnpm-workspace.yaml`. The exclusion is limited to that exact version (our deliberate security bump) and becomes a no-op once it ages out; the cooldown stays active for everything else.

## Verified end-to-end (`docker build` + `docker run`)
```
docker build .                # succeeds
# security pins present in the production image:
hono 4.12.23  qs 6.15.2  follow-redirects 1.16.0  ip-address 10.2.0  axios 1.17.0
docker run ... → GET /health  # {"status":"ok","transport":"streamable-http",...}
```

## Summary by Sourcery

Update Docker build to use a Node.js version compatible with the pinned pnpm and ensure frozen installs succeed despite a deliberate axios security upgrade.

Bug Fixes:
- Switch Docker build and runtime images to node:24-slim so the pnpm-based Docker image builds and runs successfully.
- Allow installing axios@1.17.0 despite pnpm's minimum release age check so Docker builds are not blocked.

Build:
- Bump both Dockerfile stages from node:20-slim to node:24-slim for compatibility with pnpm 11.

Chores:
- Add a targeted pnpm minimumReleaseAgeExclude entry for axios@1.17.0 to keep supply-chain cooldown enabled for all other packages.