### PR TITLE
fix(deps): resolve 2 new Dependabot alerts (round 2)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   hono@<4.12.27: 4.12.27
-  '@hono/node-server@<2.0.5': 2.0.5
+  '@hono/node-server@<2.0.10': 2.0.10
   express-rate-limit@>=8.2.0 <8.2.2: 8.2.2
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.0
   qs@<6.15.2: 6.15.2
@@ -15,7 +15,7 @@ overrides:
   body-parser@>=2.0.0 <2.3.0: 2.3.0
   vite@<7.3.5: 7.3.5
   rollup@>=4.0.0 <4.59.0: 4.59.0
-  postcss@<8.5.15: 8.5.15
+  postcss@<8.5.18: 8.5.18
   picomatch@<4.0.4: 4.0.4
   esbuild@>=0.27.3 <0.28.1: 0.28.1
   shell-quote@<1.9.0: 1.9.0
@@ -251,8 +251,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hono/node-server@2.0.5':
-    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: 4.12.27
@@ -1133,8 +1133,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   proxy-addr@2.0.7:
@@ -1603,7 +1603,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@2.0.5(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -1611,7 +1611,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.5(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -2443,7 +2443,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -2554,7 +2554,7 @@ snapshots:
       htmlparser2: 8.0.2
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   semver@5.7.2: {}
 
@@ -2750,7 +2750,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,10 @@ overrides:
   # backslash. Only patched in 2.0.5, i.e. a major bump — legitimate because
   # @modelcontextprotocol/sdk 1.30.0 widened its range to `^1.19.9 || ^2.0.5`.
   # This override therefore REQUIRES the SDK at >=1.30.0; do not lower it.
-  '@hono/node-server@<2.0.5': 2.0.5
+  # Round 2: 2.0.5 — the version this override previously targeted — is itself
+  # covered by a later advisory (<=2.0.9). SDK 1.30.0's '^1.19.9 || ^2.0.5'
+  # range admits 2.0.10, so the coupling below still holds.
+  '@hono/node-server@<2.0.10': 2.0.10
   # --- Express / routing stack ---
   express-rate-limit@>=8.2.0 <8.2.2: 8.2.2
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.0
@@ -22,7 +25,8 @@ overrides:
   # --- Build / test toolchain (vite/vitest transitive) ---
   vite@<7.3.5: 7.3.5
   rollup@>=4.0.0 <4.59.0: 4.59.0
-  postcss@<8.5.15: 8.5.15
+  # GHSA round 2: <=8.5.17 vulnerable.
+  postcss@<8.5.18: 8.5.18
   picomatch@<4.0.4: 4.0.4
   # GHSA-g7r4-m6w7-qqqr, reached via vite <- vitest (dev only).
   esbuild@>=0.27.3 <0.28.1: 0.28.1


### PR DESCRIPTION
Follow-up to #72. Two advisories published after that PR was prepared.

Verified against the resolved dependency tree before and after; both now out of range.

| Package | Selector | Advisory |
|---|---|---|
| `postcss` | `<8.5.18` → 8.5.18 | `<=8.5.17` vulnerable, via vite/vitest |
| `@hono/node-server` | `<2.0.10` → 2.0.10 | `>=2.0.0 <=2.0.9` |

## Worth noting

**2.0.5 is the exact version #72's override targeted, and it is now itself covered by a later advisory.** That is a fast-moving package — worth remembering when reading the override comments, which still explain why the 2.x line was needed at all.

The coupling documented in `pnpm-workspace.yaml` still holds unchanged: SDK 1.30.0 declares `^1.19.9 || ^2.0.5`, which admits 2.0.10, so no SDK change is required.

## Verification

- 174/174 tests pass
- `tsc` build clean
- `pnpm install --frozen-lockfile` succeeds, so the Docker build is unaffected

## Summary by Sourcery

Update dependency overrides to address newly reported vulnerabilities in transitive tooling and server runtime packages.

Build:
- Raise @hono/node-server override range to require 2.0.10 to avoid newly vulnerable 2.x versions.
- Increase postcss override to 8.5.18 to keep vite/vitest transitive dependency out of the vulnerable version range.

<!-- Generated by sourcery-ai[bot]: start fixed-security -->
- Resolves [GHSA-r28c-9q8g-f849 — PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure](https://app.sourcery.ai/dashboard/security/issues?groupId=42230427&issueIds=90540621)
<!-- Generated by sourcery-ai[bot]: end fixed-security -->