### PR TITLE
docs(plan): MCP 2026-07-28 compliance and version-bridge implementation plan

### DIFF
--- a/docs/plans/2026-07-29-mcp-2026-07-28-version-bridge.md
+++ b/docs/plans/2026-07-29-mcp-2026-07-28-version-bridge.md
@@ -51,7 +51,9 @@ Every task's requirements implicitly include this section.
 - **Keep the proxy lightweight** (per `CLAUDE.md`): no new runtime dependencies in pluggedin-mcp. Zod and the SDK are already present; everything else is hand-rolled.
 - **pluggedin-app rules** (per its `CLAUDE.md`): all user-facing text through `useTranslation`; mutations through server actions returning `{ success, data | error }`; **never** apply DB migrations directly — `pnpm db:generate` then `pnpm db:migrate`.
 - **Generic over specific:** no per-server special-casing. Revision behaviour is data in a capability table, never an `if (serverName === ...)`.
-- **Commands:** pluggedin-mcp — `npm test` (vitest, `tests/**/*.test.ts`), `npm run build` (tsc). pluggedin-app — `pnpm test` (vitest run), `pnpm lint`.
+- **Package manager is pnpm in BOTH repos** (`packageManager: pnpm@11.5.1`). Install with `pnpm install` only — never `npm install`, which would create a stray `package-lock.json` alongside the authoritative `pnpm-lock.yaml`. Dependency `overrides` live in `pnpm-workspace.yaml`, **not** in package.json: pnpm 11 no longer reads the `pnpm` field and ignores overrides placed there silently.
+- **Commands:** pluggedin-mcp — `pnpm vitest run` for tests (the bare `test` script is `vitest`, which enters watch mode in a TTY), `pnpm build` (tsc). pluggedin-app — `pnpm test` (vitest run), `pnpm lint`, `pnpm build`.
+- **Test baseline in pluggedin-app:** 42 test files / 204 tests already fail on `main`, and `pnpm lint` already reports errors. Both are pre-existing and unrelated to this plan. Judge a task by whether it changes those counts, not by whether the suite is green.
 
 ---
 
@@ -182,7 +184,7 @@ describe('revision registry', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/versions.test.ts`
+Run: `pnpm vitest run tests/protocol/versions.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/versions.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -292,14 +294,14 @@ export function capabilitiesFor(v: Revision): RevisionCapabilities {
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/versions.test.ts`
+Run: `pnpm vitest run tests/protocol/versions.test.ts`
 Expected: PASS, 5 tests.
 
 - [ ] **Step 5: Confirm nothing else regressed, then commit**
 
 ```bash
-npm test
-npm run build
+pnpm vitest run
+pnpm build
 git add src/protocol/versions.ts tests/protocol/versions.test.ts
 git commit -m "feat(protocol): add MCP revision registry and capability matrix"
 ```
@@ -387,7 +389,7 @@ describe('reserved _meta keys', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/meta.test.ts`
+Run: `pnpm vitest run tests/protocol/meta.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/meta.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -471,13 +473,13 @@ export function writeServerInfo<T extends object>(result: T, info: Implementatio
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/meta.test.ts`
+Run: `pnpm vitest run tests/protocol/meta.test.ts`
 Expected: PASS, 6 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/meta.ts tests/protocol/meta.test.ts
 git commit -m "feat(protocol): add reserved _meta key constants and accessors"
 ```
@@ -553,7 +555,7 @@ describe('2026 error codes', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/errors.test.ts`
+Run: `pnpm vitest run tests/protocol/errors.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/errors.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -606,7 +608,7 @@ export class ProtocolError extends Error {
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/errors.test.ts`
+Run: `pnpm vitest run tests/protocol/errors.test.ts`
 Expected: PASS, 5 tests.
 
 - [ ] **Step 5: Cross-reference from the legacy constants file**
@@ -626,7 +628,7 @@ In `src/constants.ts`, directly above `export const JSON_RPC_ERROR_CODES`, add:
 - [ ] **Step 6: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/errors.ts tests/protocol/errors.test.ts src/constants.ts
 git commit -m "feat(protocol): add 2026-07-28 spec-reserved error codes"
 ```
@@ -634,6 +636,14 @@ git commit -m "feat(protocol): add 2026-07-28 spec-reserved error codes"
 ---
 
 ## Task 4: Pin the SDK and stop deriving the advertised revision from it
+
+> **Overlap with the security work.** The branch `fix/dependabot-alerts` already
+> pins `@modelcontextprotocol/sdk` to `1.30.0` in both repos, because the
+> `@hono/node-server@<2.0.5` override needs an SDK whose declared range admits
+> 2.x (1.30.0 is the first). Rebase this branch on that one and Steps 3 and 7
+> below become no-ops — verify rather than re-apply. The `src/constants.ts`
+> rewrite in Steps 4–5 is still required either way: the security branch pins the
+> SDK but does not stop `MCP_PROTOCOL_VERSION` deriving from it.
 
 Today `src/constants.ts:31` sets `MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION`. The comment above it correctly records why hardcoding a subset was wrong before — but the fix went one step too far. When the SDK ships 2026-07-28, this line will silently advertise a revision whose handshake the proxy does not yet implement.
 
@@ -677,7 +687,7 @@ Note: the second assertion is a tripwire. When a future SDK does ship 2026-07-28
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/negotiation.test.ts`
+Run: `pnpm vitest run tests/protocol/negotiation.test.ts`
 Expected: FAIL — `expected '2025-11-25' to be '2026-07-28'`
 
 - [ ] **Step 3: Pin the SDK**
@@ -688,7 +698,7 @@ In `package.json`, change the dependency from `"@modelcontextprotocol/sdk": "^1.
 "@modelcontextprotocol/sdk": "1.30.0"
 ```
 
-Then run `npm install`.
+Then run `pnpm install`.
 
 - [ ] **Step 4: Rewrite the constants to read from the revision registry**
 
@@ -718,14 +728,14 @@ export const MCP_PROTOCOL_VERSION = LATEST_REVISION;
 
 - [ ] **Step 5: Run the tests to verify they pass and nothing regressed**
 
-Run: `npm test`
+Run: `pnpm vitest run`
 Expected: PASS — including the pre-existing `tests/streamable-http.test.ts`, which exercises legacy negotiation.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-npm run build
-git add package.json package-lock.json src/constants.ts tests/protocol/negotiation.test.ts
+pnpm build
+git add package.json pnpm-lock.yaml src/constants.ts tests/protocol/negotiation.test.ts
 git commit -m "fix(protocol): pin SDK to 1.30.0 and decouple advertised revision from it"
 ```
 
@@ -857,7 +867,7 @@ describe('inbound revision detection', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/detect.test.ts`
+Run: `pnpm vitest run tests/protocol/detect.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/detect.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -956,13 +966,13 @@ export function detectRevision(
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/detect.test.ts`
+Run: `pnpm vitest run tests/protocol/detect.test.ts`
 Expected: PASS, 8 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/detect.ts tests/protocol/detect.test.ts
 git commit -m "feat(protocol): detect inbound MCP revision from body, meta and headers"
 ```
@@ -1033,7 +1043,7 @@ describe('server/discover', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/discover.test.ts`
+Run: `pnpm vitest run tests/protocol/discover.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/discover.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -1094,13 +1104,13 @@ export function buildDiscoverResult(
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/discover.test.ts`
+Run: `pnpm vitest run tests/protocol/discover.test.ts`
 Expected: PASS, 6 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/discover.ts tests/protocol/discover.test.ts
 git commit -m "feat(protocol): implement mandatory server/discover responder"
 ```
@@ -1203,7 +1213,7 @@ describe('server-minted handles', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/handles.test.ts`
+Run: `pnpm vitest run tests/protocol/handles.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/handles.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -1313,13 +1323,13 @@ export class HandleStore<T> {
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/handles.test.ts`
+Run: `pnpm vitest run tests/protocol/handles.test.ts`
 Expected: PASS, 7 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/handles.ts tests/protocol/handles.test.ts
 git commit -m "feat(protocol): add server-minted handle store replacing sessions"
 ```
@@ -1435,7 +1445,7 @@ describe('deterministic tool ordering', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/cache.test.ts`
+Run: `pnpm vitest run tests/protocol/cache.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/cache.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -1504,13 +1514,13 @@ export function sortToolsDeterministically<T extends { name: string }>(tools: T[
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/cache.test.ts`
+Run: `pnpm vitest run tests/protocol/cache.test.ts`
 Expected: PASS, 8 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/cache.ts tests/protocol/cache.test.ts
 git commit -m "feat(protocol): add CacheableResult decoration and deterministic tool ordering"
 ```
@@ -1652,7 +1662,7 @@ describe('MRTR coordinator', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/mrtr.test.ts`
+Run: `pnpm vitest run tests/protocol/mrtr.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/mrtr.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -1777,13 +1787,13 @@ export class MrtrCoordinator<TParked> {
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/mrtr.test.ts`
+Run: `pnpm vitest run tests/protocol/mrtr.test.ts`
 Expected: PASS, 10 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/mrtr.ts tests/protocol/mrtr.test.ts
 git commit -m "feat(protocol): implement MRTR with legacy sampling/elicitation/roots bridging"
 ```
@@ -1902,7 +1912,7 @@ describe('x-mcp-header passthrough', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/headers.test.ts`
+Run: `pnpm vitest run tests/protocol/headers.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/headers.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -2010,13 +2020,13 @@ export function extractPassthroughHeaders(params: unknown): Record<string, strin
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/headers.test.ts`
+Run: `pnpm vitest run tests/protocol/headers.test.ts`
 Expected: PASS, 9 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/headers.ts tests/protocol/headers.test.ts
 git commit -m "feat(protocol): validate Mcp-Method/Mcp-Name and gate x-mcp-header passthrough"
 ```
@@ -2168,7 +2178,7 @@ describe('modern (2026-07-28) router', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/router.test.ts`
+Run: `pnpm vitest run tests/protocol/router.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/router.js'`
 
 - [ ] **Step 3: Write the router**
@@ -2259,7 +2269,7 @@ export function createModernRouter(options: ModernRouterOptions) {
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/router.test.ts`
+Run: `pnpm vitest run tests/protocol/router.test.ts`
 Expected: PASS, 7 tests.
 
 - [ ] **Step 5: Route 2026 traffic to the new router in `src/streamable-http.ts`**
@@ -2335,13 +2345,13 @@ import { PROTOCOL_ERROR_CODES } from './protocol/errors.js';
 
 - [ ] **Step 7: Run the whole suite to confirm legacy clients still work**
 
-Run: `npm test`
+Run: `pnpm vitest run`
 Expected: PASS — in particular the pre-existing `tests/streamable-http.test.ts`. If a legacy test now fails, the detection precedence in Task 5 is wrong; fix `detect.ts`, not the test.
 
 - [ ] **Step 8: Verify against a real client**
 
 ```bash
-npm run build
+pnpm build
 npm run inspector:manual
 ```
 
@@ -2470,7 +2480,7 @@ describe('downstream revision probing', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/registry.test.ts`
+Run: `pnpm vitest run tests/protocol/registry.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/registry.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -2562,13 +2572,13 @@ export class DownstreamRegistry {
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/registry.test.ts`
+Run: `pnpm vitest run tests/protocol/registry.test.ts`
 Expected: PASS, 6 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/registry.ts tests/protocol/registry.test.ts
 git commit -m "feat(protocol): probe and record each downstream server's revision"
 ```
@@ -2688,7 +2698,7 @@ describe('lowering results to a legacy target', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm test -- tests/protocol/lower.test.ts`
+Run: `pnpm vitest run tests/protocol/lower.test.ts`
 Expected: FAIL — `Cannot find module '../../src/protocol/lower.js'`
 
 - [ ] **Step 3: Write the implementation**
@@ -2774,13 +2784,13 @@ export function lowerResult<T extends object>(result: T, target: Revision): Reco
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm test -- tests/protocol/lower.test.ts`
+Run: `pnpm vitest run tests/protocol/lower.test.ts`
 Expected: PASS, 9 tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add src/protocol/lower.ts tests/protocol/lower.test.ts
 git commit -m "feat(protocol): lower canonical messages onto legacy target revisions"
 ```
@@ -2910,13 +2920,13 @@ describe('legacy client → modern downstream', () => {
 
 - [ ] **Step 2: Run the test**
 
-Run: `npm test -- tests/protocol/bridge.test.ts`
+Run: `pnpm vitest run tests/protocol/bridge.test.ts`
 Expected: PASS, 3 tests. If any fail, the defect is in the module under test, not in this file — fix the module.
 
 - [ ] **Step 3: Run the full suite and commit**
 
 ```bash
-npm test && npm run build
+pnpm vitest run && pnpm build
 git add tests/protocol/bridge.test.ts
 git commit -m "test(protocol): cover modern↔legacy bridging end to end"
 ```
@@ -3780,7 +3790,7 @@ In `README.md`, add to the features list:
 For each row of "What the bridge translates", confirm a test exists that covers it:
 
 ```bash
-npm test
+pnpm vitest run
 grep -rn "server/discover\|resultType\|cacheScope\|requestState\|subscriptions/listen" tests/protocol/
 ```
 

--- a/docs/plans/2026-07-29-mcp-2026-07-28-version-bridge.md
+++ b/docs/plans/2026-07-29-mcp-2026-07-28-version-bridge.md
@@ -1,0 +1,3855 @@
+# MCP 2026-07-28 Compliance & Version Bridge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make pluggedin-mcp the first MCP hub that speaks every published protocol revision on both sides at once — accepting 2024-11-05 through 2026-07-28 clients on one endpoint while transparently bridging to downstream servers stuck on any earlier revision — and bring pluggedin-app onto the same protocol core.
+
+**Architecture:** A new `src/protocol/` layer in pluggedin-mcp owns all revision knowledge. Inbound requests of *any* revision are **lifted** into a single canonical internal shape modelled on 2026-07-28 (the most explicit revision: every request self-describes via `_meta`, no ambient session state). Outbound requests to downstream servers are **lowered** to whatever that specific server was discovered to speak. Because the canonical form is a superset, translation is lossless in both directions, and features deleted from the core (sampling, roots, logging, server-initiated requests) survive as proxy-side emulation rather than breaking. The official TypeScript SDK is used only for legacy revisions; 2026-07-28 is hand-rolled because **no released SDK implements it yet** (see Finding 1).
+
+**Tech Stack:** TypeScript (ESM, NodeNext), Express 5, `@modelcontextprotocol/sdk` (pinned), Vitest, Zod. pluggedin-app side: Next.js 15 App Router, Drizzle ORM, Vitest.
+
+---
+
+## Findings That Shape This Plan
+
+These were verified against the working tree and npm on 2026-07-29. Do not re-derive them; do re-verify Finding 1 before starting, since it can change.
+
+**Finding 1 — No SDK implements 2026-07-28 yet. This is the whole opportunity.**
+`npm view @modelcontextprotocol/sdk version` → `1.30.0`. Unpacking `1.30.0` shows `LATEST_PROTOCOL_VERSION = '2025-11-25'` and `SUPPORTED_PROTOCOL_VERSIONS = ['2025-11-25','2025-06-18','2025-03-26','2024-11-05','2024-10-07']`. There is no `server/discover`, no top-level `resultType`, no MRTR. The only `input_required` string in the SDK is `TaskStatusSchema`, which is the *old* experimental tasks design that SEP-2663 replaced.
+Consequence: "upgrade the SDK" is not the fix — there is nothing to upgrade to. 2026-07-28 must be implemented by hand, which is exactly why a bridge built now has a defensible head start. It also means the SDK must be **pinned exactly**, because the moment the SDK does ship 2026-07-28, `LATEST_PROTOCOL_VERSION` silently changes meaning under `src/constants.ts:31`.
+
+**Finding 2 — The two repos are on different revisions.**
+- `pluggedin-mcp` v2.3.0, `@modelcontextprotocol/sdk` `^1.29.0` (installed 1.29.0), negotiates via `LATEST_PROTOCOL_VERSION` → effectively 2025-11-25.
+- `pluggedin-app` v3.3.0, `@modelcontextprotocol/sdk` `^1.27.1` (installed 1.27.1), with `2024-11-05` hardcoded in four places:
+  `lib/mcp/client-wrapper.ts:860`, `lib/mcp/streamable-http/handler.ts:263`, `app/actions/trigger-mcp-oauth.ts:365`, `app/actions/test-mcp-connection.ts:251`.
+The hub and the platform therefore disagree about what protocol they speak. Phase C closes this.
+
+**Finding 3 — Session-id is load-bearing in three places and all three break under a stateless client.**
+- `pluggedin-mcp/src/middleware.ts:230` mints a session id per request when absent, and `src/streamable-http.ts:45` keeps an in-memory `Map` with TTL + LRU. A `stateless` option already exists (`src/streamable-http.ts:126`) but is off by default and creates a throwaway transport per request rather than implementing the stateless *protocol*.
+- `pluggedin-app/app/api/mcp/route.ts:73-78` and `:137-142` hard-reject GET and DELETE without `Mcp-Session-Id`.
+- `pluggedin-app/lib/mcp/streamable-http/handler.ts:40-58` requires either `method === 'initialize'` or a session id; a 2026-07-28 client sends neither.
+A 2026-07-28 client hitting the hosted endpoint today gets a 400 on its first non-initialize call.
+
+**Finding 4 — `StreamableHTTPWrapper.ts` (451 lines) exists only to capture `Mcp-Session-Id` through CORS.** Under 2026-07-28 that entire concern disappears. It must stay for legacy downstream servers but must not be on the 2026 path.
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Backward compatibility is non-negotiable.** Revisions `2024-10-07`, `2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25` MUST keep working unchanged after every task. Any task that breaks an existing `tests/*.test.ts` is a failed task.
+- **Pin the SDK exactly.** `"@modelcontextprotocol/sdk": "1.30.0"` — no caret, in both repos. `src/constants.ts` MUST NOT derive the advertised latest version from `LATEST_PROTOCOL_VERSION`.
+- **Canonical revision string:** `'2026-07-28'`. Full ordered set, oldest→newest:
+  `['2024-10-07','2024-11-05','2025-03-26','2025-06-18','2025-11-25','2026-07-28']`.
+- **Reserved `_meta` keys (exact strings, copied from the spec):**
+  `io.modelcontextprotocol/protocolVersion`, `io.modelcontextprotocol/clientCapabilities`, `io.modelcontextprotocol/clientInfo`, `io.modelcontextprotocol/serverInfo`, `io.modelcontextprotocol/logLevel`, `io.modelcontextprotocol/subscriptionId`, `traceparent`, `tracestate`, `baggage`.
+- **Error codes (exact values):** `HeaderMismatch = -32020`, `MissingRequiredClientCapability = -32021`, `UnsupportedProtocolVersion = -32022`. Resource-not-found moves from `-32002` to `-32602`. The range `-32000..-32019` stays implementation-defined; existing `UNAUTHORIZED = -32001` and `APPLICATION_ERROR = -32000` in `src/constants.ts` are grandfathered and MUST NOT be renumbered.
+- **`resultType`** is required on every result: `"complete"` normally, `"input_required"` for MRTR. Results received from earlier-revision servers that omit it MUST be treated as `"complete"`.
+- **Cache fields** `ttlMs` (number, milliseconds) and `cacheScope` (`"public" | "private"`) are required on results of `tools/list`, `prompts/list`, `resources/list`, `resources/read`, `resources/templates/list`.
+- **ESM import style:** relative imports carry the `.js` extension (`./constants.js`). Match it.
+- **Keep the proxy lightweight** (per `CLAUDE.md`): no new runtime dependencies in pluggedin-mcp. Zod and the SDK are already present; everything else is hand-rolled.
+- **pluggedin-app rules** (per its `CLAUDE.md`): all user-facing text through `useTranslation`; mutations through server actions returning `{ success, data | error }`; **never** apply DB migrations directly — `pnpm db:generate` then `pnpm db:migrate`.
+- **Generic over specific:** no per-server special-casing. Revision behaviour is data in a capability table, never an `if (serverName === ...)`.
+- **Commands:** pluggedin-mcp — `npm test` (vitest, `tests/**/*.test.ts`), `npm run build` (tsc). pluggedin-app — `pnpm test` (vitest run), `pnpm lint`.
+
+---
+
+## File Structure
+
+### pluggedin-mcp — new `src/protocol/` layer
+
+| File | Responsibility |
+|---|---|
+| `src/protocol/versions.ts` | The single source of truth: ordered revision list, per-revision capability matrix, comparison helpers. Nothing else in the codebase may hardcode a revision string. |
+| `src/protocol/meta.ts` | Reserved `_meta` key constants and typed read/write helpers. |
+| `src/protocol/errors.ts` | 2026 error codes + `ProtocolError` class. Extends, does not replace, `JSON_RPC_ERROR_CODES`. |
+| `src/protocol/detect.ts` | Infers the inbound revision from a raw JSON-RPC request + headers. |
+| `src/protocol/canonical.ts` | Canonical internal request/result types (2026-shaped) that the rest of the proxy works against. |
+| `src/protocol/lift.ts` | Any inbound revision → canonical. (North side, request direction.) |
+| `src/protocol/lower.ts` | Canonical → any target revision. (North side response direction + south side request direction.) |
+| `src/protocol/discover.ts` | `server/discover` responder (north) and downstream prober with `initialize` fallback (south). |
+| `src/protocol/handles.ts` | Server-minted opaque handles that replace `Mcp-Session-Id` for cross-call state. |
+| `src/protocol/cache.ts` | `CacheableResult` decoration + deterministic list ordering. |
+| `src/protocol/mrtr.ts` | Multi Round-Trip Requests: `InputRequiredResult`, `requestState` correlation, and emulation of the deprecated server-initiated `sampling`/`elicitation`/`roots` calls. |
+| `src/protocol/subscriptions.ts` | `subscriptions/listen` long-poll stream replacing HTTP GET + `resources/subscribe`. |
+| `src/protocol/headers.ts` | `Mcp-Method` / `Mcp-Name` validation and `x-mcp-header` passthrough. |
+| `src/protocol/registry.ts` | Per-downstream-server recorded revision + capabilities, populated by `discover.ts`. |
+
+Modified: `src/constants.ts`, `src/middleware.ts`, `src/streamable-http.ts`, `src/mcp-proxy.ts`, `package.json`.
+
+Tests mirror the layout under `tests/protocol/`.
+
+### pluggedin-app — alignment only
+
+Modified: `package.json`, `lib/mcp/client-wrapper.ts`, `lib/mcp/streamable-http/handler.ts`, `lib/mcp/transports/StreamableHTTPWrapper.ts`, `app/api/mcp/route.ts`, `app/actions/trigger-mcp-oauth.ts`, `app/actions/test-mcp-connection.ts`, `lib/security/cors.ts`.
+Created: `lib/mcp/protocol/versions.ts` (a thin re-statement of the revision table; the app does not need the full bridge).
+
+---
+
+# Phase A — Protocol foundation (pluggedin-mcp, north side)
+
+## Task 1: Revision registry and capability matrix
+
+Everything downstream of this task reads revision behaviour from here. No other file may contain a revision string literal.
+
+**Files:**
+- Create: `src/protocol/versions.ts`
+- Test: `tests/protocol/versions.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Revision = '2024-10-07' | '2024-11-05' | '2025-03-26' | '2025-06-18' | '2025-11-25' | '2026-07-28'`
+  - `const REVISIONS: readonly Revision[]` (oldest → newest)
+  - `const LATEST_REVISION: Revision` (`'2026-07-28'`)
+  - `function isRevision(v: unknown): v is Revision`
+  - `function compareRevisions(a: Revision, b: Revision): number`
+  - `function atLeast(v: Revision, floor: Revision): boolean`
+  - `interface RevisionCapabilities { stateless, requiresInitialize, hasServerDiscover, hasResultType, hasMrtr, hasCacheableResult, hasSubscriptionsListen, sessionHeader, serverInitiatedRequests, hasPing, hasLoggingSetLevel }` — all `boolean` except `sessionHeader: boolean`
+  - `function capabilitiesFor(v: Revision): RevisionCapabilities`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/versions.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  REVISIONS,
+  LATEST_REVISION,
+  isRevision,
+  compareRevisions,
+  atLeast,
+  capabilitiesFor,
+} from '../../src/protocol/versions.js';
+
+describe('revision registry', () => {
+  it('lists every published revision oldest-first', () => {
+    expect(REVISIONS).toEqual([
+      '2024-10-07',
+      '2024-11-05',
+      '2025-03-26',
+      '2025-06-18',
+      '2025-11-25',
+      '2026-07-28',
+    ]);
+    expect(LATEST_REVISION).toBe('2026-07-28');
+  });
+
+  it('recognises only published revisions', () => {
+    expect(isRevision('2026-07-28')).toBe(true);
+    expect(isRevision('2027-01-01')).toBe(false);
+    expect(isRevision(null)).toBe(false);
+  });
+
+  it('orders revisions chronologically', () => {
+    expect(compareRevisions('2024-11-05', '2026-07-28')).toBeLessThan(0);
+    expect(compareRevisions('2026-07-28', '2024-11-05')).toBeGreaterThan(0);
+    expect(compareRevisions('2025-11-25', '2025-11-25')).toBe(0);
+    expect(atLeast('2026-07-28', '2025-11-25')).toBe(true);
+    expect(atLeast('2025-06-18', '2025-11-25')).toBe(false);
+  });
+
+  it('marks 2026-07-28 stateless and handshake-free', () => {
+    const caps = capabilitiesFor('2026-07-28');
+    expect(caps.stateless).toBe(true);
+    expect(caps.requiresInitialize).toBe(false);
+    expect(caps.hasServerDiscover).toBe(true);
+    expect(caps.hasResultType).toBe(true);
+    expect(caps.hasMrtr).toBe(true);
+    expect(caps.hasCacheableResult).toBe(true);
+    expect(caps.hasSubscriptionsListen).toBe(true);
+    expect(caps.sessionHeader).toBe(false);
+    expect(caps.serverInitiatedRequests).toBe(false);
+    expect(caps.hasPing).toBe(false);
+    expect(caps.hasLoggingSetLevel).toBe(false);
+  });
+
+  it('marks every pre-2026 revision stateful with server-initiated requests', () => {
+    for (const rev of REVISIONS.filter((r) => r !== '2026-07-28')) {
+      const caps = capabilitiesFor(rev);
+      expect(caps.stateless, rev).toBe(false);
+      expect(caps.requiresInitialize, rev).toBe(true);
+      expect(caps.hasServerDiscover, rev).toBe(false);
+      expect(caps.hasMrtr, rev).toBe(false);
+      expect(caps.serverInitiatedRequests, rev).toBe(true);
+      expect(caps.sessionHeader, rev).toBe(true);
+      expect(caps.hasPing, rev).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/versions.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/versions.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/versions.ts
+/**
+ * MCP revision registry — the single source of truth for protocol-version
+ * behaviour across the proxy.
+ *
+ * No other module may contain a revision string literal. When a new revision
+ * ships, it is added here and nowhere else.
+ *
+ * Deliberately NOT derived from the SDK's SUPPORTED_PROTOCOL_VERSIONS: as of
+ * SDK 1.30.0 the SDK tops out at 2025-11-25, and the proxy needs to speak
+ * 2026-07-28 before the SDK does.
+ */
+
+export type Revision =
+  | '2024-10-07'
+  | '2024-11-05'
+  | '2025-03-26'
+  | '2025-06-18'
+  | '2025-11-25'
+  | '2026-07-28';
+
+export const REVISIONS: readonly Revision[] = [
+  '2024-10-07',
+  '2024-11-05',
+  '2025-03-26',
+  '2025-06-18',
+  '2025-11-25',
+  '2026-07-28',
+] as const;
+
+export const LATEST_REVISION: Revision = '2026-07-28';
+
+export function isRevision(v: unknown): v is Revision {
+  return typeof v === 'string' && (REVISIONS as readonly string[]).includes(v);
+}
+
+export function compareRevisions(a: Revision, b: Revision): number {
+  return REVISIONS.indexOf(a) - REVISIONS.indexOf(b);
+}
+
+export function atLeast(v: Revision, floor: Revision): boolean {
+  return compareRevisions(v, floor) >= 0;
+}
+
+export interface RevisionCapabilities {
+  /** No protocol-level session; every request self-describes. */
+  stateless: boolean;
+  /** Requires the initialize/notifications/initialized handshake. */
+  requiresInitialize: boolean;
+  /** Implements the server/discover RPC. */
+  hasServerDiscover: boolean;
+  /** Results carry a required resultType discriminator. */
+  hasResultType: boolean;
+  /** Uses Multi Round-Trip Requests instead of server-initiated requests. */
+  hasMrtr: boolean;
+  /** List/read results carry ttlMs + cacheScope. */
+  hasCacheableResult: boolean;
+  /** Uses subscriptions/listen rather than HTTP GET + resources/subscribe. */
+  hasSubscriptionsListen: boolean;
+  /** Uses the Mcp-Session-Id header. */
+  sessionHeader: boolean;
+  /** Server may originate sampling/elicitation/roots requests. */
+  serverInitiatedRequests: boolean;
+  /** Supports the ping method. */
+  hasPing: boolean;
+  /** Supports logging/setLevel (vs per-request _meta logLevel). */
+  hasLoggingSetLevel: boolean;
+}
+
+const MODERN: RevisionCapabilities = {
+  stateless: true,
+  requiresInitialize: false,
+  hasServerDiscover: true,
+  hasResultType: true,
+  hasMrtr: true,
+  hasCacheableResult: true,
+  hasSubscriptionsListen: true,
+  sessionHeader: false,
+  serverInitiatedRequests: false,
+  hasPing: false,
+  hasLoggingSetLevel: false,
+};
+
+const LEGACY: RevisionCapabilities = {
+  stateless: false,
+  requiresInitialize: true,
+  hasServerDiscover: false,
+  hasResultType: false,
+  hasMrtr: false,
+  hasCacheableResult: false,
+  hasSubscriptionsListen: false,
+  sessionHeader: true,
+  serverInitiatedRequests: true,
+  hasPing: true,
+  hasLoggingSetLevel: true,
+};
+
+export function capabilitiesFor(v: Revision): RevisionCapabilities {
+  return v === '2026-07-28' ? { ...MODERN } : { ...LEGACY };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/versions.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Confirm nothing else regressed, then commit**
+
+```bash
+npm test
+npm run build
+git add src/protocol/versions.ts tests/protocol/versions.test.ts
+git commit -m "feat(protocol): add MCP revision registry and capability matrix"
+```
+
+---
+
+## Task 2: Reserved `_meta` keys and typed accessors
+
+**Files:**
+- Create: `src/protocol/meta.ts`
+- Test: `tests/protocol/meta.test.ts`
+
+**Interfaces:**
+- Consumes: `Revision`, `isRevision` from `src/protocol/versions.js`.
+- Produces:
+  - `const META_KEYS` — frozen record with keys `protocolVersion`, `clientCapabilities`, `clientInfo`, `serverInfo`, `logLevel`, `subscriptionId`, `traceparent`, `tracestate`, `baggage`
+  - `interface Implementation { name: string; version: string; title?: string }`
+  - `function readProtocolVersion(meta: unknown): Revision | undefined`
+  - `function readClientInfo(meta: unknown): Implementation | undefined`
+  - `function readLogLevel(meta: unknown): string | undefined`
+  - `function readTraceContext(meta: unknown): { traceparent?: string; tracestate?: string; baggage?: string }`
+  - `function writeServerInfo<T extends object>(result: T, info: Implementation): T`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/meta.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  META_KEYS,
+  readProtocolVersion,
+  readClientInfo,
+  readLogLevel,
+  readTraceContext,
+  writeServerInfo,
+} from '../../src/protocol/meta.js';
+
+describe('reserved _meta keys', () => {
+  it('uses the exact spec key strings', () => {
+    expect(META_KEYS.protocolVersion).toBe('io.modelcontextprotocol/protocolVersion');
+    expect(META_KEYS.clientCapabilities).toBe('io.modelcontextprotocol/clientCapabilities');
+    expect(META_KEYS.clientInfo).toBe('io.modelcontextprotocol/clientInfo');
+    expect(META_KEYS.serverInfo).toBe('io.modelcontextprotocol/serverInfo');
+    expect(META_KEYS.logLevel).toBe('io.modelcontextprotocol/logLevel');
+    expect(META_KEYS.subscriptionId).toBe('io.modelcontextprotocol/subscriptionId');
+    expect(META_KEYS.traceparent).toBe('traceparent');
+  });
+
+  it('reads a valid protocol version and rejects an invalid one', () => {
+    expect(readProtocolVersion({ 'io.modelcontextprotocol/protocolVersion': '2026-07-28' }))
+      .toBe('2026-07-28');
+    expect(readProtocolVersion({ 'io.modelcontextprotocol/protocolVersion': '2030-01-01' }))
+      .toBeUndefined();
+    expect(readProtocolVersion(undefined)).toBeUndefined();
+    expect(readProtocolVersion('not an object')).toBeUndefined();
+  });
+
+  it('reads clientInfo only when name and version are strings', () => {
+    expect(readClientInfo({ 'io.modelcontextprotocol/clientInfo': { name: 'claude', version: '1.2' } }))
+      .toEqual({ name: 'claude', version: '1.2' });
+    expect(readClientInfo({ 'io.modelcontextprotocol/clientInfo': { name: 'claude' } }))
+      .toBeUndefined();
+  });
+
+  it('reads the per-request log level', () => {
+    expect(readLogLevel({ 'io.modelcontextprotocol/logLevel': 'debug' })).toBe('debug');
+    expect(readLogLevel({})).toBeUndefined();
+  });
+
+  it('extracts only the OpenTelemetry keys that are present', () => {
+    expect(readTraceContext({ traceparent: '00-abc-def-01', baggage: 'k=v' }))
+      .toEqual({ traceparent: '00-abc-def-01', baggage: 'k=v' });
+    expect(readTraceContext({})).toEqual({});
+  });
+
+  it('writes serverInfo into a result without clobbering existing _meta', () => {
+    const result = { resultType: 'complete', _meta: { existing: 1 } } as Record<string, any>;
+    const out = writeServerInfo(result, { name: 'pluggedin-mcp', version: '2.3.0' });
+    expect(out._meta.existing).toBe(1);
+    expect(out._meta['io.modelcontextprotocol/serverInfo'])
+      .toEqual({ name: 'pluggedin-mcp', version: '2.3.0' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/meta.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/meta.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/meta.ts
+/**
+ * Reserved _meta keys for MCP 2026-07-28.
+ *
+ * With the initialize handshake removed, per-request _meta is the only place
+ * identity, version and capability information travels. These key strings are
+ * normative — a typo silently degrades a modern client to legacy handling, so
+ * they are declared exactly once, here.
+ */
+
+import { isRevision, type Revision } from './versions.js';
+
+export const META_KEYS = Object.freeze({
+  protocolVersion: 'io.modelcontextprotocol/protocolVersion',
+  clientCapabilities: 'io.modelcontextprotocol/clientCapabilities',
+  clientInfo: 'io.modelcontextprotocol/clientInfo',
+  serverInfo: 'io.modelcontextprotocol/serverInfo',
+  logLevel: 'io.modelcontextprotocol/logLevel',
+  subscriptionId: 'io.modelcontextprotocol/subscriptionId',
+  traceparent: 'traceparent',
+  tracestate: 'tracestate',
+  baggage: 'baggage',
+} as const);
+
+export interface Implementation {
+  name: string;
+  version: string;
+  title?: string;
+}
+
+function asRecord(meta: unknown): Record<string, unknown> | undefined {
+  return meta && typeof meta === 'object' && !Array.isArray(meta)
+    ? (meta as Record<string, unknown>)
+    : undefined;
+}
+
+export function readProtocolVersion(meta: unknown): Revision | undefined {
+  const value = asRecord(meta)?.[META_KEYS.protocolVersion];
+  return isRevision(value) ? value : undefined;
+}
+
+export function readClientInfo(meta: unknown): Implementation | undefined {
+  const value = asRecord(asRecord(meta)?.[META_KEYS.clientInfo]);
+  if (!value) return undefined;
+  const { name, version, title } = value;
+  if (typeof name !== 'string' || typeof version !== 'string') return undefined;
+  return typeof title === 'string' ? { name, version, title } : { name, version };
+}
+
+export function readLogLevel(meta: unknown): string | undefined {
+  const value = asRecord(meta)?.[META_KEYS.logLevel];
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function readTraceContext(meta: unknown): {
+  traceparent?: string;
+  tracestate?: string;
+  baggage?: string;
+} {
+  const record = asRecord(meta);
+  const out: { traceparent?: string; tracestate?: string; baggage?: string } = {};
+  if (!record) return out;
+  for (const key of ['traceparent', 'tracestate', 'baggage'] as const) {
+    const value = record[META_KEYS[key]];
+    if (typeof value === 'string') out[key] = value;
+  }
+  return out;
+}
+
+export function writeServerInfo<T extends object>(result: T, info: Implementation): T {
+  const target = result as T & { _meta?: Record<string, unknown> };
+  target._meta = { ...(target._meta ?? {}), [META_KEYS.serverInfo]: info };
+  return target;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/meta.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/meta.ts tests/protocol/meta.test.ts
+git commit -m "feat(protocol): add reserved _meta key constants and accessors"
+```
+
+---
+
+## Task 3: 2026 error codes
+
+The spec renumbered the codes introduced in draft and partitioned the server-error range. The existing `-32000`/`-32001` in `src/constants.ts` are explicitly grandfathered and must survive.
+
+**Files:**
+- Create: `src/protocol/errors.ts`
+- Test: `tests/protocol/errors.test.ts`
+- Modify: `src/constants.ts` (add a doc comment pointing at the new module; do not renumber anything)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `const PROTOCOL_ERROR_CODES` with `HEADER_MISMATCH: -32020`, `MISSING_REQUIRED_CLIENT_CAPABILITY: -32021`, `UNSUPPORTED_PROTOCOL_VERSION: -32022`, `INVALID_PARAMS: -32602`
+  - `class ProtocolError extends Error { code: number; data?: unknown; toJsonRpc(id: string | number | null): object }`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/errors.test.ts
+import { describe, expect, it } from 'vitest';
+import { PROTOCOL_ERROR_CODES, ProtocolError } from '../../src/protocol/errors.js';
+import { JSON_RPC_ERROR_CODES } from '../../src/constants.js';
+
+describe('2026 error codes', () => {
+  it('uses the renumbered spec-reserved codes', () => {
+    expect(PROTOCOL_ERROR_CODES.HEADER_MISMATCH).toBe(-32020);
+    expect(PROTOCOL_ERROR_CODES.MISSING_REQUIRED_CLIENT_CAPABILITY).toBe(-32021);
+    expect(PROTOCOL_ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION).toBe(-32022);
+  });
+
+  it('maps resource-not-found onto Invalid Params per JSON-RPC alignment', () => {
+    expect(PROTOCOL_ERROR_CODES.INVALID_PARAMS).toBe(-32602);
+  });
+
+  it('leaves grandfathered implementation-defined codes untouched', () => {
+    expect(JSON_RPC_ERROR_CODES.UNAUTHORIZED).toBe(-32001);
+    expect(JSON_RPC_ERROR_CODES.APPLICATION_ERROR).toBe(-32000);
+  });
+
+  it('serialises to a JSON-RPC error envelope', () => {
+    const err = new ProtocolError(
+      PROTOCOL_ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION,
+      'Unsupported protocol version: 2030-01-01',
+      { supported: ['2026-07-28'] },
+    );
+    expect(err.toJsonRpc(7)).toEqual({
+      jsonrpc: '2.0',
+      id: 7,
+      error: {
+        code: -32022,
+        message: 'Unsupported protocol version: 2030-01-01',
+        data: { supported: ['2026-07-28'] },
+      },
+    });
+  });
+
+  it('omits data when none was supplied', () => {
+    const err = new ProtocolError(PROTOCOL_ERROR_CODES.HEADER_MISMATCH, 'Mcp-Method mismatch');
+    expect(err.toJsonRpc(null)).toEqual({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32020, message: 'Mcp-Method mismatch' },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/errors.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/errors.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/errors.ts
+/**
+ * Error codes introduced by MCP 2026-07-28.
+ *
+ * The spec partitions the JSON-RPC server-error range: -32000..-32019 stays
+ * implementation-defined (our existing UNAUTHORIZED/-32001 and
+ * APPLICATION_ERROR/-32000 in constants.ts are grandfathered there and must not
+ * move), while -32020..-32099 is reserved for the specification itself.
+ */
+
+export const PROTOCOL_ERROR_CODES = Object.freeze({
+  /** Mcp-Method or Mcp-Name header disagrees with the JSON-RPC body. */
+  HEADER_MISMATCH: -32020,
+  /** Request needs a client capability the caller did not declare. */
+  MISSING_REQUIRED_CLIENT_CAPABILITY: -32021,
+  /** Requested protocol revision is not one this server speaks. */
+  UNSUPPORTED_PROTOCOL_VERSION: -32022,
+  /** Standard JSON-RPC Invalid Params — now also used for resource-not-found. */
+  INVALID_PARAMS: -32602,
+} as const);
+
+export class ProtocolError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+    readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = 'ProtocolError';
+  }
+
+  toJsonRpc(id: string | number | null): object {
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: this.code,
+        message: this.message,
+        ...(this.data !== undefined ? { data: this.data } : {}),
+      },
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/errors.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Cross-reference from the legacy constants file**
+
+In `src/constants.ts`, directly above `export const JSON_RPC_ERROR_CODES`, add:
+
+```ts
+/**
+ * Legacy JSON-RPC error codes. These sit in the implementation-defined
+ * -32000..-32019 partition and are grandfathered by the 2026-07-28 error-code
+ * allocation policy — do NOT renumber them.
+ *
+ * Spec-reserved codes (-32020 and below) live in ./protocol/errors.ts.
+ */
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/errors.ts tests/protocol/errors.test.ts src/constants.ts
+git commit -m "feat(protocol): add 2026-07-28 spec-reserved error codes"
+```
+
+---
+
+## Task 4: Pin the SDK and stop deriving the advertised revision from it
+
+Today `src/constants.ts:31` sets `MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION`. The comment above it correctly records why hardcoding a subset was wrong before — but the fix went one step too far. When the SDK ships 2026-07-28, this line will silently advertise a revision whose handshake the proxy does not yet implement.
+
+**Files:**
+- Modify: `package.json`, `src/constants.ts`
+- Test: `tests/protocol/negotiation.test.ts`
+
+**Interfaces:**
+- Consumes: `REVISIONS`, `LATEST_REVISION` from `src/protocol/versions.js`.
+- Produces: `SUPPORTED_MCP_PROTOCOL_VERSIONS` (now `REVISIONS`), `MCP_PROTOCOL_VERSION` (now `LATEST_REVISION`) — same exported names, new sources.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/negotiation.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  MCP_PROTOCOL_VERSION,
+  SUPPORTED_MCP_PROTOCOL_VERSIONS,
+} from '../../src/constants.js';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
+
+describe('protocol negotiation surface', () => {
+  it('advertises 2026-07-28 regardless of what the bundled SDK tops out at', () => {
+    expect(MCP_PROTOCOL_VERSION).toBe('2026-07-28');
+  });
+
+  it('is decoupled from the SDK, which still lags the spec', () => {
+    expect(LATEST_PROTOCOL_VERSION).not.toBe(MCP_PROTOCOL_VERSION);
+  });
+
+  it('still accepts every legacy revision the SDK can speak', () => {
+    for (const legacy of ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25']) {
+      expect(SUPPORTED_MCP_PROTOCOL_VERSIONS).toContain(legacy);
+    }
+  });
+});
+```
+
+Note: the second assertion is a tripwire. When a future SDK does ship 2026-07-28 it will fail, which is the signal to re-evaluate whether the hand-rolled layer can defer to the SDK. Replace it then; do not delete it now.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/negotiation.test.ts`
+Expected: FAIL — `expected '2025-11-25' to be '2026-07-28'`
+
+- [ ] **Step 3: Pin the SDK**
+
+In `package.json`, change the dependency from `"@modelcontextprotocol/sdk": "^1.29.0"` to:
+
+```json
+"@modelcontextprotocol/sdk": "1.30.0"
+```
+
+Then run `npm install`.
+
+- [ ] **Step 4: Rewrite the constants to read from the revision registry**
+
+Replace the `SUPPORTED_MCP_PROTOCOL_VERSIONS` and `MCP_PROTOCOL_VERSION` block in `src/constants.ts` (currently lines 9–31, including the SDK import) with:
+
+```ts
+import { LATEST_REVISION, REVISIONS } from './protocol/versions.js';
+
+/**
+ * Supported MCP protocol revisions.
+ *
+ * Sourced from ./protocol/versions.ts, NOT from the SDK. As of SDK 1.30.0 the
+ * bundled SDK tops out at 2025-11-25 while this proxy also speaks 2026-07-28
+ * via the hand-rolled bridge in ./protocol/. Deriving from the SDK would both
+ * hide 2026-07-28 today and silently start advertising it — handshake and all —
+ * the moment the SDK bumps.
+ *
+ * @see https://modelcontextprotocol.io/specification
+ */
+export const SUPPORTED_MCP_PROTOCOL_VERSIONS = REVISIONS;
+
+/**
+ * Newest revision this proxy advertises. Sent in response headers.
+ */
+export const MCP_PROTOCOL_VERSION = LATEST_REVISION;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass and nothing regressed**
+
+Run: `npm test`
+Expected: PASS — including the pre-existing `tests/streamable-http.test.ts`, which exercises legacy negotiation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npm run build
+git add package.json package-lock.json src/constants.ts tests/protocol/negotiation.test.ts
+git commit -m "fix(protocol): pin SDK to 1.30.0 and decouple advertised revision from it"
+```
+
+---
+
+## Task 5: Inbound revision detection
+
+A 2026-07-28 client sends no `initialize` and no session header — it just posts `tools/list` with `_meta`. A 2024-11-05 client posts `initialize`. Both land on the same endpoint. This task decides which is which.
+
+Detection precedence, highest first:
+1. `_meta['io.modelcontextprotocol/protocolVersion']` on the body → that revision (2026-style, self-describing).
+2. `params.protocolVersion` on an `initialize` body → that revision (legacy handshake).
+3. `Mcp-Protocol-Version` header → that revision.
+4. Presence of `Mcp-Session-Id` header → legacy, assume `2025-11-25`.
+5. Nothing → `2025-11-25`, the newest revision a released SDK client can actually speak.
+
+**Files:**
+- Create: `src/protocol/detect.ts`
+- Test: `tests/protocol/detect.test.ts`
+
+**Interfaces:**
+- Consumes: `Revision`, `isRevision`, `capabilitiesFor` from `versions.js`; `readProtocolVersion`, `readClientInfo` from `meta.js`; `PROTOCOL_ERROR_CODES`, `ProtocolError` from `errors.js`.
+- Produces:
+  - `interface DetectedRevision { revision: Revision; source: 'meta' | 'initialize' | 'header' | 'session' | 'default' }`
+  - `function detectRevision(body: unknown, headers: Record<string, string | string[] | undefined>): DetectedRevision`
+  - Throws `ProtocolError(UNSUPPORTED_PROTOCOL_VERSION)` when an explicit but unknown revision is supplied.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/detect.test.ts
+import { describe, expect, it } from 'vitest';
+import { detectRevision } from '../../src/protocol/detect.js';
+import { ProtocolError } from '../../src/protocol/errors.js';
+
+const noHeaders = {};
+
+describe('inbound revision detection', () => {
+  it('detects 2026 from body _meta with no handshake and no session', () => {
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {
+        _meta: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' },
+      },
+    };
+    expect(detectRevision(body, noHeaders)).toEqual({
+      revision: '2026-07-28',
+      source: 'meta',
+    });
+  });
+
+  it('detects a legacy revision from the initialize handshake', () => {
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2024-11-05', capabilities: {} },
+    };
+    expect(detectRevision(body, noHeaders)).toEqual({
+      revision: '2024-11-05',
+      source: 'initialize',
+    });
+  });
+
+  it('prefers body _meta over a stale header', () => {
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: { _meta: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' } },
+    };
+    const headers = { 'mcp-protocol-version': '2024-11-05' };
+    expect(detectRevision(body, headers).revision).toBe('2026-07-28');
+  });
+
+  it('falls back to the Mcp-Protocol-Version header', () => {
+    const body = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+    expect(detectRevision(body, { 'mcp-protocol-version': '2025-06-18' })).toEqual({
+      revision: '2025-06-18',
+      source: 'header',
+    });
+  });
+
+  it('treats a bare session header as a legacy client', () => {
+    const body = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+    expect(detectRevision(body, { 'mcp-session-id': 'abc' })).toEqual({
+      revision: '2025-11-25',
+      source: 'session',
+    });
+  });
+
+  it('defaults to the newest SDK-speakable revision when nothing is stated', () => {
+    expect(detectRevision({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, noHeaders)).toEqual({
+      revision: '2025-11-25',
+      source: 'default',
+    });
+  });
+
+  it('rejects an explicitly stated unknown revision', () => {
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: { _meta: { 'io.modelcontextprotocol/protocolVersion': '2030-01-01' } },
+    };
+    expect(() => detectRevision(body, noHeaders)).toThrow(ProtocolError);
+    try {
+      detectRevision(body, noHeaders);
+    } catch (e) {
+      expect((e as ProtocolError).code).toBe(-32022);
+    }
+  });
+
+  it('handles a batch body by reading the first element', () => {
+    const body = [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: { _meta: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' } },
+      },
+    ];
+    expect(detectRevision(body, noHeaders).revision).toBe('2026-07-28');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/detect.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/detect.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/detect.ts
+/**
+ * Infers which MCP revision an inbound request speaks.
+ *
+ * This is the hinge of the whole bridge. A 2026-07-28 client sends no
+ * initialize and no Mcp-Session-Id — it posts a plain method call carrying its
+ * revision in params._meta. A pre-2026 client either opens with initialize or
+ * carries a session header. Both hit the same endpoint, so detection must be
+ * unambiguous and must never upgrade a legacy client by accident.
+ */
+
+import { isRevision, REVISIONS, type Revision } from './versions.js';
+import { readProtocolVersion } from './meta.js';
+import { PROTOCOL_ERROR_CODES, ProtocolError } from './errors.js';
+
+/** Newest revision any released SDK client can actually speak (SDK 1.30.0). */
+const LEGACY_DEFAULT: Revision = '2025-11-25';
+
+export interface DetectedRevision {
+  revision: Revision;
+  source: 'meta' | 'initialize' | 'header' | 'session' | 'default';
+}
+
+function firstMessage(body: unknown): Record<string, any> | undefined {
+  const message = Array.isArray(body) ? body[0] : body;
+  return message && typeof message === 'object' ? (message as Record<string, any>) : undefined;
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+): string | undefined {
+  const raw = headers[name] ?? headers[name.toLowerCase()];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function unsupported(value: string): ProtocolError {
+  return new ProtocolError(
+    PROTOCOL_ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION,
+    `Unsupported MCP protocol version: ${value}`,
+    { supported: REVISIONS },
+  );
+}
+
+export function detectRevision(
+  body: unknown,
+  headers: Record<string, string | string[] | undefined>,
+): DetectedRevision {
+  const message = firstMessage(body);
+
+  // 1. Self-describing 2026-style request.
+  const rawMeta = message?.params?._meta;
+  if (rawMeta && typeof rawMeta === 'object') {
+    const stated = (rawMeta as Record<string, unknown>)[
+      'io.modelcontextprotocol/protocolVersion'
+    ];
+    if (stated !== undefined) {
+      const revision = readProtocolVersion(rawMeta);
+      if (!revision) throw unsupported(String(stated));
+      return { revision, source: 'meta' };
+    }
+  }
+
+  // 2. Legacy initialize handshake.
+  if (message?.method === 'initialize') {
+    const stated = message.params?.protocolVersion;
+    if (stated !== undefined) {
+      if (!isRevision(stated)) throw unsupported(String(stated));
+      return { revision: stated, source: 'initialize' };
+    }
+  }
+
+  // 3. Explicit transport header.
+  const headerRevision = headerValue(headers, 'mcp-protocol-version');
+  if (headerRevision !== undefined) {
+    if (!isRevision(headerRevision)) throw unsupported(headerRevision);
+    return { revision: headerRevision, source: 'header' };
+  }
+
+  // 4. A session header can only come from a pre-2026 client.
+  if (headerValue(headers, 'mcp-session-id') !== undefined) {
+    return { revision: LEGACY_DEFAULT, source: 'session' };
+  }
+
+  // 5. Nothing stated. Assume the newest revision a released SDK speaks —
+  //    never 2026-07-28, which would hand a legacy client stateless semantics.
+  return { revision: LEGACY_DEFAULT, source: 'default' };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/detect.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/detect.ts tests/protocol/detect.test.ts
+git commit -m "feat(protocol): detect inbound MCP revision from body, meta and headers"
+```
+
+---
+
+## Task 6: `server/discover` responder
+
+2026-07-28 makes this RPC mandatory: `Servers MUST implement this RPC to advertise their supported protocol versions, capabilities, and identity.` It must answer without any handshake and without auth, because clients call it *before* anything else.
+
+**Files:**
+- Create: `src/protocol/discover.ts`
+- Test: `tests/protocol/discover.test.ts`
+
+**Interfaces:**
+- Consumes: `REVISIONS`, `LATEST_REVISION` from `versions.js`; `Implementation`, `META_KEYS` from `meta.js`.
+- Produces:
+  - `interface DiscoverResult { resultType: 'complete'; protocolVersions: readonly Revision[]; capabilities: Record<string, unknown>; serverInfo: Implementation; extensions?: Record<string, unknown> }`
+  - `function buildDiscoverResult(info: Implementation, extensions?: Record<string, unknown>): DiscoverResult`
+  - `function isDiscoverRequest(body: unknown): boolean`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/discover.test.ts
+import { describe, expect, it } from 'vitest';
+import { buildDiscoverResult, isDiscoverRequest } from '../../src/protocol/discover.js';
+
+const info = { name: 'pluggedin-mcp', version: '2.3.0' };
+
+describe('server/discover', () => {
+  it('recognises the discover request', () => {
+    expect(isDiscoverRequest({ jsonrpc: '2.0', id: 1, method: 'server/discover' })).toBe(true);
+    expect(isDiscoverRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' })).toBe(false);
+    expect(isDiscoverRequest(null)).toBe(false);
+  });
+
+  it('advertises every revision the proxy bridges, newest first', () => {
+    const result = buildDiscoverResult(info);
+    expect(result.protocolVersions[0]).toBe('2026-07-28');
+    expect(result.protocolVersions).toContain('2024-11-05');
+    expect(result.protocolVersions).toHaveLength(6);
+  });
+
+  it('is a complete result carrying server identity', () => {
+    const result = buildDiscoverResult(info);
+    expect(result.resultType).toBe('complete');
+    expect(result.serverInfo).toEqual(info);
+  });
+
+  it('declares the aggregation capabilities the hub actually implements', () => {
+    const result = buildDiscoverResult(info);
+    expect(result.capabilities.tools).toEqual({ listChanged: true });
+    expect(result.capabilities.resources).toEqual({ listChanged: true, subscribe: true });
+    expect(result.capabilities.prompts).toEqual({ listChanged: true });
+  });
+
+  it('passes declared extensions through', () => {
+    const result = buildDiscoverResult(info, { 'io.modelcontextprotocol/tasks': {} });
+    expect(result.extensions).toEqual({ 'io.modelcontextprotocol/tasks': {} });
+  });
+
+  it('omits the extensions field when none are declared', () => {
+    expect(buildDiscoverResult(info).extensions).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/discover.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/discover.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/discover.ts
+/**
+ * server/discover — mandatory under MCP 2026-07-28.
+ *
+ * Clients MAY call this before any other request to pick a protocol version up
+ * front, and use it as a backward-compatibility probe on STDIO. It therefore
+ * must answer with no handshake, no session and no authentication.
+ */
+
+import { LATEST_REVISION, REVISIONS, type Revision } from './versions.js';
+import type { Implementation } from './meta.js';
+
+export interface DiscoverResult {
+  resultType: 'complete';
+  protocolVersions: readonly Revision[];
+  capabilities: Record<string, unknown>;
+  serverInfo: Implementation;
+  extensions?: Record<string, unknown>;
+}
+
+export function isDiscoverRequest(body: unknown): boolean {
+  return (
+    !!body &&
+    typeof body === 'object' &&
+    !Array.isArray(body) &&
+    (body as Record<string, unknown>).method === 'server/discover'
+  );
+}
+
+export function buildDiscoverResult(
+  info: Implementation,
+  extensions?: Record<string, unknown>,
+): DiscoverResult {
+  // Newest first: clients pick the first entry they recognise.
+  const protocolVersions = [...REVISIONS].reverse() as Revision[];
+  if (protocolVersions[0] !== LATEST_REVISION) {
+    throw new Error('Revision registry is not ordered oldest-first');
+  }
+
+  return {
+    resultType: 'complete',
+    protocolVersions,
+    capabilities: {
+      tools: { listChanged: true },
+      resources: { listChanged: true, subscribe: true },
+      prompts: { listChanged: true },
+    },
+    serverInfo: info,
+    ...(extensions ? { extensions } : {}),
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/discover.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/discover.ts tests/protocol/discover.test.ts
+git commit -m "feat(protocol): implement mandatory server/discover responder"
+```
+
+---
+
+## Task 7: Server-minted handles replacing `Mcp-Session-Id`
+
+The spec's replacement for protocol sessions: *"Servers that need cross-call state use explicit, server-minted handles passed as ordinary tool arguments."* The handle store replaces the `Map` in `src/streamable-http.ts:45` for 2026 clients while that map stays for legacy ones.
+
+**Files:**
+- Create: `src/protocol/handles.ts`
+- Test: `tests/protocol/handles.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface HandleStoreOptions { ttlMs?: number; maxEntries?: number; now?: () => number }`
+  - `class HandleStore<T> { mint(value: T): string; get(handle: string): T | undefined; touch(handle: string): boolean; delete(handle: string): boolean; sweep(): number; get size(): number }`
+
+Reuse the existing TTL and cap constants — `SESSION_TTL_MS` and `MAX_SESSIONS` from `src/constants.js` — as the defaults, so operators tune one thing.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/handles.test.ts
+import { describe, expect, it } from 'vitest';
+import { HandleStore } from '../../src/protocol/handles.js';
+
+describe('server-minted handles', () => {
+  it('mints opaque, unguessable, unique handles', () => {
+    const store = new HandleStore<number>();
+    const a = store.mint(1);
+    const b = store.mint(2);
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[A-Za-z0-9_-]{22,}$/);
+    expect(store.get(a)).toBe(1);
+    expect(store.get(b)).toBe(2);
+  });
+
+  it('returns undefined for an unknown handle', () => {
+    expect(new HandleStore<number>().get('nope')).toBeUndefined();
+  });
+
+  it('expires handles past their TTL', () => {
+    let clock = 1_000;
+    const store = new HandleStore<string>({ ttlMs: 100, now: () => clock });
+    const handle = store.mint('state');
+    clock = 1_050;
+    expect(store.get(handle)).toBe('state');
+    clock = 1_200;
+    expect(store.get(handle)).toBeUndefined();
+  });
+
+  it('extends the deadline on access', () => {
+    let clock = 0;
+    const store = new HandleStore<string>({ ttlMs: 100, now: () => clock });
+    const handle = store.mint('state');
+    clock = 90;
+    expect(store.get(handle)).toBe('state');
+    clock = 170;
+    expect(store.get(handle)).toBe('state');
+  });
+
+  it('evicts the least recently used entry at capacity', () => {
+    let clock = 0;
+    const store = new HandleStore<string>({ maxEntries: 2, now: () => clock });
+    const first = store.mint('a');
+    clock = 1;
+    const second = store.mint('b');
+    clock = 2;
+    store.get(first);
+    clock = 3;
+    const third = store.mint('c');
+    expect(store.size).toBe(2);
+    expect(store.get(second)).toBeUndefined();
+    expect(store.get(first)).toBe('a');
+    expect(store.get(third)).toBe('c');
+  });
+
+  it('sweeps expired entries and reports the count', () => {
+    let clock = 0;
+    const store = new HandleStore<string>({ ttlMs: 10, now: () => clock });
+    store.mint('a');
+    store.mint('b');
+    clock = 100;
+    expect(store.sweep()).toBe(2);
+    expect(store.size).toBe(0);
+  });
+
+  it('deletes a handle explicitly', () => {
+    const store = new HandleStore<string>();
+    const handle = store.mint('a');
+    expect(store.delete(handle)).toBe(true);
+    expect(store.delete(handle)).toBe(false);
+    expect(store.get(handle)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/handles.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/handles.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/handles.ts
+/**
+ * Server-minted handles — the 2026-07-28 replacement for protocol sessions.
+ *
+ * The spec removed Mcp-Session-Id and the per-connection notion of state:
+ * "Servers that need cross-call state use explicit, server-minted handles
+ * passed as ordinary tool arguments." A handle is opaque to the client, so it
+ * carries no routing meaning and any instance can serve any request as long as
+ * the store is shared.
+ *
+ * This in-process implementation matches today's in-memory session Map. Making
+ * it durable (Redis/Postgres) is a store swap behind the same interface, not a
+ * protocol change — which is precisely the point of handles over sessions.
+ */
+
+import { randomBytes } from 'crypto';
+import { MAX_SESSIONS, SESSION_TTL_MS } from '../constants.js';
+
+export interface HandleStoreOptions {
+  ttlMs?: number;
+  maxEntries?: number;
+  /** Injectable clock; tests use it instead of fake timers. */
+  now?: () => number;
+}
+
+interface Entry<T> {
+  value: T;
+  lastAccess: number;
+}
+
+export class HandleStore<T> {
+  private readonly entries = new Map<string, Entry<T>>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+
+  constructor(options: HandleStoreOptions = {}) {
+    this.ttlMs = options.ttlMs ?? SESSION_TTL_MS;
+    this.maxEntries = options.maxEntries ?? MAX_SESSIONS;
+    this.now = options.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  mint(value: T): string {
+    if (this.entries.size >= this.maxEntries) {
+      this.sweep();
+      if (this.entries.size >= this.maxEntries) this.evictOldest();
+    }
+    // 24 base64url chars of CSPRNG output: opaque and unguessable.
+    const handle = randomBytes(18).toString('base64url');
+    this.entries.set(handle, { value, lastAccess: this.now() });
+    return handle;
+  }
+
+  get(handle: string): T | undefined {
+    const entry = this.entries.get(handle);
+    if (!entry) return undefined;
+    if (this.now() - entry.lastAccess > this.ttlMs) {
+      this.entries.delete(handle);
+      return undefined;
+    }
+    entry.lastAccess = this.now();
+    return entry.value;
+  }
+
+  touch(handle: string): boolean {
+    return this.get(handle) !== undefined;
+  }
+
+  delete(handle: string): boolean {
+    return this.entries.delete(handle);
+  }
+
+  sweep(): number {
+    const deadline = this.now() - this.ttlMs;
+    let removed = 0;
+    for (const [handle, entry] of this.entries) {
+      if (entry.lastAccess < deadline) {
+        this.entries.delete(handle);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  private evictOldest(): void {
+    let oldestHandle: string | undefined;
+    let oldestAccess = Infinity;
+    for (const [handle, entry] of this.entries) {
+      if (entry.lastAccess < oldestAccess) {
+        oldestAccess = entry.lastAccess;
+        oldestHandle = handle;
+      }
+    }
+    if (oldestHandle) this.entries.delete(oldestHandle);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/handles.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/handles.ts tests/protocol/handles.test.ts
+git commit -m "feat(protocol): add server-minted handle store replacing sessions"
+```
+
+---
+
+## Task 8: `CacheableResult` and deterministic list ordering
+
+This is the task with the highest direct payoff for an aggregator: `cacheScope: "public"` is the spec's explicit permission for a shared intermediary — a hub — to cache a downstream result, and deterministic tool ordering raises the client's prompt-cache hit rate across the merged list.
+
+**Files:**
+- Create: `src/protocol/cache.ts`
+- Test: `tests/protocol/cache.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type CacheScope = 'public' | 'private'`
+  - `interface CacheableResult { ttlMs: number; cacheScope: CacheScope }`
+  - `const CACHEABLE_METHODS: readonly string[]` — `tools/list`, `prompts/list`, `resources/list`, `resources/read`, `resources/templates/list`
+  - `function isCacheableMethod(method: string): boolean`
+  - `function decorateCacheable<T extends object>(result: T, opts: { ttlMs: number; cacheScope: CacheScope }): T & CacheableResult`
+  - `function sortToolsDeterministically<T extends { name: string }>(tools: T[]): T[]`
+  - `function narrowestScope(scopes: CacheScope[]): CacheScope`
+  - `function shortestTtl(ttls: number[]): number`
+
+The last two exist because the hub merges N downstream lists into one: the merged result may only claim the weakest guarantee any contributor gave it. One `private` downstream makes the whole merged list `private`; the merged `ttlMs` is the minimum.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/cache.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  CACHEABLE_METHODS,
+  decorateCacheable,
+  isCacheableMethod,
+  narrowestScope,
+  shortestTtl,
+  sortToolsDeterministically,
+} from '../../src/protocol/cache.js';
+
+describe('CacheableResult', () => {
+  it('covers exactly the five methods the spec requires', () => {
+    expect([...CACHEABLE_METHODS].sort()).toEqual([
+      'prompts/list',
+      'resources/list',
+      'resources/read',
+      'resources/templates/list',
+      'tools/list',
+    ]);
+    expect(isCacheableMethod('tools/list')).toBe(true);
+    expect(isCacheableMethod('tools/call')).toBe(false);
+  });
+
+  it('adds ttlMs and cacheScope without disturbing the payload', () => {
+    const decorated = decorateCacheable(
+      { tools: [{ name: 'a' }], resultType: 'complete' as const },
+      { ttlMs: 60_000, cacheScope: 'public' },
+    );
+    expect(decorated.ttlMs).toBe(60_000);
+    expect(decorated.cacheScope).toBe('public');
+    expect(decorated.tools).toEqual([{ name: 'a' }]);
+    expect(decorated.resultType).toBe('complete');
+  });
+});
+
+describe('merged-result guarantees', () => {
+  it('degrades to private if any contributor is private', () => {
+    expect(narrowestScope(['public', 'public'])).toBe('public');
+    expect(narrowestScope(['public', 'private'])).toBe('private');
+    expect(narrowestScope([])).toBe('private');
+  });
+
+  it('takes the shortest contributing TTL', () => {
+    expect(shortestTtl([60_000, 5_000, 30_000])).toBe(5_000);
+    expect(shortestTtl([])).toBe(0);
+  });
+});
+
+describe('deterministic tool ordering', () => {
+  it('sorts by name so repeated list calls hash identically', () => {
+    const tools = [{ name: 'zulu' }, { name: 'alpha' }, { name: 'mike' }];
+    expect(sortToolsDeterministically(tools).map((t) => t.name)).toEqual([
+      'alpha',
+      'mike',
+      'zulu',
+    ]);
+  });
+
+  it('is stable across shuffles of the same set', () => {
+    const a = sortToolsDeterministically([{ name: 'b' }, { name: 'a' }, { name: 'c' }]);
+    const b = sortToolsDeterministically([{ name: 'c' }, { name: 'b' }, { name: 'a' }]);
+    expect(a).toEqual(b);
+  });
+
+  it('orders UUID-prefixed aggregated names by codepoint, not locale', () => {
+    const tools = [{ name: 'B_tool' }, { name: 'a_tool' }, { name: 'A_tool' }];
+    expect(sortToolsDeterministically(tools).map((t) => t.name)).toEqual([
+      'A_tool',
+      'B_tool',
+      'a_tool',
+    ]);
+  });
+
+  it('does not mutate its input', () => {
+    const tools = [{ name: 'b' }, { name: 'a' }];
+    sortToolsDeterministically(tools);
+    expect(tools.map((t) => t.name)).toEqual(['b', 'a']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/cache.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/cache.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/cache.ts
+/**
+ * CacheableResult support (SEP-2549) and deterministic list ordering.
+ *
+ * The single most aggregator-friendly change in 2026-07-28: cacheScope
+ * "public" is explicit permission for a shared intermediary — a hub like this
+ * one — to cache a downstream result. Because the hub merges N downstream
+ * lists into one, the merged result may only claim the weakest guarantee any
+ * contributor gave: narrowest scope, shortest TTL.
+ *
+ * Deterministic ordering is a client-side win: identical bytes across repeated
+ * tools/list calls keep the model's prompt cache warm.
+ */
+
+export type CacheScope = 'public' | 'private';
+
+export interface CacheableResult {
+  ttlMs: number;
+  cacheScope: CacheScope;
+}
+
+export const CACHEABLE_METHODS: readonly string[] = [
+  'tools/list',
+  'prompts/list',
+  'resources/list',
+  'resources/read',
+  'resources/templates/list',
+] as const;
+
+export function isCacheableMethod(method: string): boolean {
+  return CACHEABLE_METHODS.includes(method);
+}
+
+export function decorateCacheable<T extends object>(
+  result: T,
+  opts: { ttlMs: number; cacheScope: CacheScope },
+): T & CacheableResult {
+  return { ...result, ttlMs: opts.ttlMs, cacheScope: opts.cacheScope };
+}
+
+/** A merged result is public only if every contributor was. */
+export function narrowestScope(scopes: CacheScope[]): CacheScope {
+  if (scopes.length === 0) return 'private';
+  return scopes.every((s) => s === 'public') ? 'public' : 'private';
+}
+
+/** A merged result is stale as soon as its earliest contributor is. */
+export function shortestTtl(ttls: number[]): number {
+  if (ttls.length === 0) return 0;
+  return Math.min(...ttls);
+}
+
+/**
+ * Sort by raw codepoint, not locale: localeCompare would order differently
+ * across runtimes and defeat the byte-identical guarantee the caching is for.
+ */
+export function sortToolsDeterministically<T extends { name: string }>(tools: T[]): T[] {
+  return [...tools].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/cache.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/cache.ts tests/protocol/cache.test.ts
+git commit -m "feat(protocol): add CacheableResult decoration and deterministic tool ordering"
+```
+
+---
+
+## Task 9: Multi Round-Trip Requests and legacy emulation
+
+The hardest and most valuable translation in the bridge. Pre-2026 servers push `sampling/createMessage`, `elicitation/create` and `roots/list` *at* the client mid-request. 2026 clients cannot receive those. Instead the server returns `InputRequiredResult`, and the client retries the original request with `inputResponses` attached.
+
+The proxy sits exactly in the middle, so it can convert in both directions:
+- **Legacy downstream → 2026 client:** capture the server-initiated request, park the in-flight call under a `requestState` token, return `resultType: "input_required"`. On retry, replay the parked call with the client's answer.
+- **2026 downstream → legacy client:** receive `input_required`, satisfy it by issuing the equivalent server-initiated request to the legacy client, then retry downstream automatically. The legacy client never learns MRTR exists.
+
+Note the spec removed `notifications/elicitation/complete` and the `elicitationId` field precisely because correlation now lives in `requestState` — so `requestState` must round-trip byte-identically.
+
+**Files:**
+- Create: `src/protocol/mrtr.ts`
+- Test: `tests/protocol/mrtr.test.ts`
+
+**Interfaces:**
+- Consumes: `HandleStore` from `handles.js`.
+- Produces:
+  - `type InputRequestKind = 'sampling' | 'elicitation' | 'roots'`
+  - `interface InputRequest { kind: InputRequestKind; id: string; params: Record<string, unknown> }`
+  - `interface InputResponse { id: string; result?: unknown; error?: { code: number; message: string } }`
+  - `interface InputRequiredResult { resultType: 'input_required'; inputRequests: InputRequest[]; requestState: string }`
+  - `interface CompleteResult { resultType: 'complete'; [k: string]: unknown }`
+  - `function isInputRequired(result: unknown): result is InputRequiredResult`
+  - `function normalizeResultType<T extends object>(result: T): T & { resultType: 'complete' }`
+  - `function toInputRequest(method: string, id: string, params: Record<string, unknown>): InputRequest`
+  - `class MrtrCoordinator<TParked> { park(parked: TParked, requests: InputRequest[]): InputRequiredResult; resume(requestState: string, responses: InputResponse[]): { parked: TParked; responses: Map<string, InputResponse> } | undefined }`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/mrtr.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  MrtrCoordinator,
+  isInputRequired,
+  normalizeResultType,
+  toInputRequest,
+} from '../../src/protocol/mrtr.js';
+
+describe('resultType normalisation', () => {
+  it('treats a result from an earlier-protocol server as complete', () => {
+    expect(normalizeResultType({ tools: [] }).resultType).toBe('complete');
+  });
+
+  it('leaves an explicit complete result alone', () => {
+    const result = { resultType: 'complete' as const, tools: [{ name: 'a' }] };
+    expect(normalizeResultType(result)).toEqual(result);
+  });
+
+  it('identifies an input_required result', () => {
+    expect(
+      isInputRequired({ resultType: 'input_required', inputRequests: [], requestState: 'x' }),
+    ).toBe(true);
+    expect(isInputRequired({ resultType: 'complete' })).toBe(false);
+    expect(isInputRequired(null)).toBe(false);
+  });
+});
+
+describe('legacy server-initiated request mapping', () => {
+  it('maps the three deprecated methods onto MRTR input kinds', () => {
+    expect(toInputRequest('sampling/createMessage', 'r1', { messages: [] }).kind).toBe('sampling');
+    expect(toInputRequest('elicitation/create', 'r2', { message: 'hi' }).kind).toBe('elicitation');
+    expect(toInputRequest('roots/list', 'r3', {}).kind).toBe('roots');
+  });
+
+  it('preserves the original params verbatim', () => {
+    const params = { messages: [{ role: 'user', content: 'hi' }], maxTokens: 10 };
+    expect(toInputRequest('sampling/createMessage', 'r1', params).params).toEqual(params);
+  });
+
+  it('rejects a method that is not a server-initiated request', () => {
+    expect(() => toInputRequest('tools/call', 'r1', {})).toThrow(/not a server-initiated/i);
+  });
+});
+
+describe('MRTR coordinator', () => {
+  it('parks an in-flight call and returns an input_required result', () => {
+    const coordinator = new MrtrCoordinator<{ method: string }>();
+    const result = coordinator.park({ method: 'tools/call' }, [
+      toInputRequest('elicitation/create', 'q1', { message: 'Which repo?' }),
+    ]);
+
+    expect(result.resultType).toBe('input_required');
+    expect(result.inputRequests).toHaveLength(1);
+    expect(result.inputRequests[0].kind).toBe('elicitation');
+    expect(typeof result.requestState).toBe('string');
+    expect(result.requestState.length).toBeGreaterThan(0);
+  });
+
+  it('resumes the parked call keyed by requestState', () => {
+    const coordinator = new MrtrCoordinator<{ method: string }>();
+    const parked = coordinator.park({ method: 'tools/call' }, [
+      toInputRequest('elicitation/create', 'q1', {}),
+    ]);
+
+    const resumed = coordinator.resume(parked.requestState, [
+      { id: 'q1', result: { action: 'accept', content: { repo: 'pluggedin-mcp' } } },
+    ]);
+
+    expect(resumed?.parked).toEqual({ method: 'tools/call' });
+    expect(resumed?.responses.get('q1')?.result).toEqual({
+      action: 'accept',
+      content: { repo: 'pluggedin-mcp' },
+    });
+  });
+
+  it('returns undefined for an unknown or already-consumed requestState', () => {
+    const coordinator = new MrtrCoordinator<{ method: string }>();
+    const parked = coordinator.park({ method: 'tools/call' }, [
+      toInputRequest('roots/list', 'q1', {}),
+    ]);
+
+    expect(coordinator.resume('bogus', [])).toBeUndefined();
+    expect(coordinator.resume(parked.requestState, [{ id: 'q1', result: {} }])).toBeDefined();
+    // Single-use: a replayed retry must not re-execute the parked call.
+    expect(coordinator.resume(parked.requestState, [{ id: 'q1', result: {} }])).toBeUndefined();
+  });
+
+  it('carries an input error back to the parked call', () => {
+    const coordinator = new MrtrCoordinator<{ method: string }>();
+    const parked = coordinator.park({ method: 'tools/call' }, [
+      toInputRequest('sampling/createMessage', 'q1', {}),
+    ]);
+
+    const resumed = coordinator.resume(parked.requestState, [
+      { id: 'q1', error: { code: -32001, message: 'User declined' } },
+    ]);
+
+    expect(resumed?.responses.get('q1')?.error?.message).toBe('User declined');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/mrtr.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/mrtr.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/mrtr.ts
+/**
+ * Multi Round-Trip Requests (SEP-2322).
+ *
+ * 2026-07-28 removed server-initiated requests. Where a pre-2026 server would
+ * push sampling/createMessage, elicitation/create or roots/list at the client
+ * mid-call, a 2026 server instead returns resultType "input_required" carrying
+ * inputRequests; the client answers by RETRYING the original request with
+ * inputResponses attached.
+ *
+ * The proxy sits in the middle and translates both directions, so a 2026 client
+ * can drive a legacy downstream server and vice versa. Correlation across the
+ * retry lives entirely in requestState — the spec deleted
+ * notifications/elicitation/complete and the elicitationId field for exactly
+ * this reason — so requestState must round-trip untouched.
+ */
+
+import { HandleStore } from './handles.js';
+
+export type InputRequestKind = 'sampling' | 'elicitation' | 'roots';
+
+export interface InputRequest {
+  kind: InputRequestKind;
+  id: string;
+  params: Record<string, unknown>;
+}
+
+export interface InputResponse {
+  id: string;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export interface InputRequiredResult {
+  resultType: 'input_required';
+  inputRequests: InputRequest[];
+  requestState: string;
+}
+
+export interface CompleteResult {
+  resultType: 'complete';
+  [key: string]: unknown;
+}
+
+const METHOD_TO_KIND: Readonly<Record<string, InputRequestKind>> = Object.freeze({
+  'sampling/createMessage': 'sampling',
+  'elicitation/create': 'elicitation',
+  'roots/list': 'roots',
+});
+
+export function isInputRequired(result: unknown): result is InputRequiredResult {
+  return (
+    !!result &&
+    typeof result === 'object' &&
+    (result as Record<string, unknown>).resultType === 'input_required'
+  );
+}
+
+/**
+ * Spec: clients MUST treat results from earlier-protocol servers that omit
+ * resultType as "complete".
+ */
+export function normalizeResultType<T extends object>(result: T): T & { resultType: 'complete' } {
+  const typed = result as T & { resultType?: string };
+  if (typed.resultType === 'complete') return typed as T & { resultType: 'complete' };
+  return { ...result, resultType: 'complete' as const };
+}
+
+export function toInputRequest(
+  method: string,
+  id: string,
+  params: Record<string, unknown>,
+): InputRequest {
+  const kind = METHOD_TO_KIND[method];
+  if (!kind) {
+    throw new Error(
+      `${method} is not a server-initiated request; expected one of ${Object.keys(METHOD_TO_KIND).join(', ')}`,
+    );
+  }
+  return { kind, id, params };
+}
+
+/**
+ * Parks an in-flight call while its input requests are answered out of band.
+ *
+ * Entries are single-use: a replayed retry must not re-execute the parked call.
+ */
+export class MrtrCoordinator<TParked> {
+  private readonly store: HandleStore<TParked>;
+
+  constructor(store?: HandleStore<TParked>) {
+    this.store = store ?? new HandleStore<TParked>();
+  }
+
+  park(parked: TParked, requests: InputRequest[]): InputRequiredResult {
+    return {
+      resultType: 'input_required',
+      inputRequests: requests,
+      requestState: this.store.mint(parked),
+    };
+  }
+
+  resume(
+    requestState: string,
+    responses: InputResponse[],
+  ): { parked: TParked; responses: Map<string, InputResponse> } | undefined {
+    const parked = this.store.get(requestState);
+    if (parked === undefined) return undefined;
+    this.store.delete(requestState);
+    return {
+      parked,
+      responses: new Map(responses.map((response) => [response.id, response])),
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/mrtr.test.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/mrtr.ts tests/protocol/mrtr.test.ts
+git commit -m "feat(protocol): implement MRTR with legacy sampling/elicitation/roots bridging"
+```
+
+---
+
+## Task 10: `Mcp-Method` / `Mcp-Name` headers and `x-mcp-header`
+
+SEP-2243 requires these headers on Streamable HTTP POSTs so load balancers can route without parsing the JSON body — the thing that makes MCP "a first-class HTTP workload". A mismatch between header and body is `HeaderMismatch (-32020)`.
+
+**Files:**
+- Create: `src/protocol/headers.ts`
+- Test: `tests/protocol/headers.test.ts`
+
+**Interfaces:**
+- Consumes: `PROTOCOL_ERROR_CODES`, `ProtocolError` from `errors.js`; `Revision`, `capabilitiesFor` from `versions.js`.
+- Produces:
+  - `function validateMcpHeaders(body: unknown, headers: Record<string, string | string[] | undefined>, revision: Revision): void` — throws `ProtocolError(HEADER_MISMATCH)` on disagreement; a no-op for pre-2026 revisions
+  - `function extractPassthroughHeaders(params: unknown): Record<string, string>` — pulls `x-mcp-header` prefixed tool arguments
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/headers.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  extractPassthroughHeaders,
+  validateMcpHeaders,
+} from '../../src/protocol/headers.js';
+import { ProtocolError } from '../../src/protocol/errors.js';
+
+const callBody = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'tools/call',
+  params: { name: 'github_search' },
+};
+
+describe('Mcp-Method / Mcp-Name validation', () => {
+  it('accepts headers that agree with the body', () => {
+    expect(() =>
+      validateMcpHeaders(
+        callBody,
+        { 'mcp-method': 'tools/call', 'mcp-name': 'github_search' },
+        '2026-07-28',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a header that disagrees with the body method', () => {
+    expect(() =>
+      validateMcpHeaders(callBody, { 'mcp-method': 'tools/list' }, '2026-07-28'),
+    ).toThrow(ProtocolError);
+    try {
+      validateMcpHeaders(callBody, { 'mcp-method': 'tools/list' }, '2026-07-28');
+    } catch (e) {
+      expect((e as ProtocolError).code).toBe(-32020);
+    }
+  });
+
+  it('rejects a header that disagrees with the body name', () => {
+    expect(() =>
+      validateMcpHeaders(
+        callBody,
+        { 'mcp-method': 'tools/call', 'mcp-name': 'gitlab_search' },
+        '2026-07-28',
+      ),
+    ).toThrow(ProtocolError);
+  });
+
+  it('tolerates absent headers rather than failing the request', () => {
+    expect(() => validateMcpHeaders(callBody, {}, '2026-07-28')).not.toThrow();
+  });
+
+  it('is a no-op for pre-2026 revisions even on mismatch', () => {
+    expect(() =>
+      validateMcpHeaders(callBody, { 'mcp-method': 'tools/list' }, '2025-11-25'),
+    ).not.toThrow();
+  });
+});
+
+describe('x-mcp-header passthrough', () => {
+  it('extracts prefixed arguments and strips the prefix', () => {
+    expect(
+      extractPassthroughHeaders({
+        name: 'search',
+        arguments: { 'x-mcp-header-X-Tenant': 'acme', query: 'q' },
+      }),
+    ).toEqual({ 'X-Tenant': 'acme' });
+  });
+
+  it('ignores non-string values', () => {
+    expect(
+      extractPassthroughHeaders({ arguments: { 'x-mcp-header-X-Count': 5 } }),
+    ).toEqual({});
+  });
+
+  it('returns an empty object when there is nothing to extract', () => {
+    expect(extractPassthroughHeaders({ arguments: { query: 'q' } })).toEqual({});
+    expect(extractPassthroughHeaders(undefined)).toEqual({});
+  });
+
+  it('refuses to smuggle hop-by-hop or auth headers through tool arguments', () => {
+    expect(
+      extractPassthroughHeaders({
+        arguments: {
+          'x-mcp-header-Authorization': 'Bearer stolen',
+          'x-mcp-header-Host': 'evil.example',
+          'x-mcp-header-X-Safe': 'ok',
+        },
+      }),
+    ).toEqual({ 'X-Safe': 'ok' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/headers.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/headers.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/headers.ts
+/**
+ * Standard MCP request headers (SEP-2243).
+ *
+ * Mcp-Method and Mcp-Name let an L7 load balancer route and rate-limit without
+ * parsing the JSON-RPC body — a precondition for treating MCP as an ordinary
+ * HTTP workload. Because they duplicate body content they can disagree with it,
+ * so a mismatch is a hard error (-32020) rather than a silently-preferred value.
+ *
+ * x-mcp-header-* tool arguments let a tool author forward a header to the
+ * upstream API. That is an SSRF-adjacent capability: the denylist below stops a
+ * tool argument from overriding transport identity or borrowing the proxy's
+ * credentials.
+ */
+
+import { PROTOCOL_ERROR_CODES, ProtocolError } from './errors.js';
+import { capabilitiesFor, type Revision } from './versions.js';
+
+const PASSTHROUGH_PREFIX = 'x-mcp-header-';
+
+/**
+ * Headers a tool argument may never set: authentication material, transport
+ * identity, and hop-by-hop controls.
+ */
+const FORBIDDEN_PASSTHROUGH = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'host',
+  'connection',
+  'upgrade',
+  'transfer-encoding',
+  'content-length',
+  'te',
+  'trailer',
+  'keep-alive',
+  'mcp-session-id',
+  'mcp-protocol-version',
+  'mcp-method',
+  'mcp-name',
+]);
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+): string | undefined {
+  const raw = headers[name] ?? headers[name.toLowerCase()];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function validateMcpHeaders(
+  body: unknown,
+  headers: Record<string, string | string[] | undefined>,
+  revision: Revision,
+): void {
+  // These headers only exist from 2026-07-28 onward; on a legacy request any
+  // value present is noise from an intermediary, not a contract.
+  if (!capabilitiesFor(revision).hasResultType) return;
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return;
+
+  const message = body as Record<string, any>;
+
+  const declaredMethod = headerValue(headers, 'mcp-method');
+  if (declaredMethod !== undefined && declaredMethod !== message.method) {
+    throw new ProtocolError(
+      PROTOCOL_ERROR_CODES.HEADER_MISMATCH,
+      `Mcp-Method header "${declaredMethod}" does not match body method "${message.method}"`,
+    );
+  }
+
+  const declaredName = headerValue(headers, 'mcp-name');
+  const bodyName = message.params?.name;
+  if (declaredName !== undefined && bodyName !== undefined && declaredName !== bodyName) {
+    throw new ProtocolError(
+      PROTOCOL_ERROR_CODES.HEADER_MISMATCH,
+      `Mcp-Name header "${declaredName}" does not match body params.name "${bodyName}"`,
+    );
+  }
+}
+
+export function extractPassthroughHeaders(params: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!params || typeof params !== 'object') return out;
+
+  const args = (params as Record<string, any>).arguments;
+  if (!args || typeof args !== 'object') return out;
+
+  for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+    if (!key.startsWith(PASSTHROUGH_PREFIX)) continue;
+    if (typeof value !== 'string') continue;
+    const headerName = key.slice(PASSTHROUGH_PREFIX.length);
+    if (FORBIDDEN_PASSTHROUGH.has(headerName.toLowerCase())) continue;
+    out[headerName] = value;
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/headers.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/headers.ts tests/protocol/headers.test.ts
+git commit -m "feat(protocol): validate Mcp-Method/Mcp-Name and gate x-mcp-header passthrough"
+```
+
+---
+
+## Task 11: Wire the 2026 path into the Express server
+
+Everything so far is pure and untested against a socket. This task makes a real 2026-07-28 client work end to end while leaving every legacy path on the existing SDK transport.
+
+Routing rule inside `mcpHandler`: detect the revision; if it is `2026-07-28`, serve it from the new protocol layer; otherwise fall through to `resolveTransport` exactly as today.
+
+**Files:**
+- Modify: `src/streamable-http.ts`, `src/middleware.ts`
+- Create: `src/protocol/router.ts`
+- Test: `tests/protocol/router.test.ts`
+
+**Interfaces:**
+- Consumes: `detectRevision` from `detect.js`; `isDiscoverRequest`, `buildDiscoverResult` from `discover.js`; `validateMcpHeaders` from `headers.js`; `normalizeResultType` from `mrtr.js`; `writeServerInfo` from `meta.js`; `ProtocolError` from `errors.js`.
+- Produces:
+  - `interface ModernRouterOptions { serverInfo: Implementation; dispatch: (method: string, params: unknown) => Promise<Record<string, unknown>> }`
+  - `function createModernRouter(options: ModernRouterOptions): (body: unknown, headers: Record<string, string | string[] | undefined>) => Promise<{ status: number; body: unknown }>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/router.test.ts
+import { describe, expect, it, vi } from 'vitest';
+import { createModernRouter } from '../../src/protocol/router.js';
+
+const serverInfo = { name: 'pluggedin-mcp', version: '2.3.0' };
+const modernMeta = { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' };
+
+describe('modern (2026-07-28) router', () => {
+  it('answers server/discover with no handshake, session or auth', async () => {
+    const dispatch = vi.fn();
+    const route = createModernRouter({ serverInfo, dispatch });
+
+    const { status, body } = await route(
+      { jsonrpc: '2.0', id: 1, method: 'server/discover' },
+      {},
+    );
+
+    expect(status).toBe(200);
+    expect((body as any).result.protocolVersions[0]).toBe('2026-07-28');
+    expect((body as any).result.serverInfo).toEqual(serverInfo);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('serves a bare tools/list with no prior initialize', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ tools: [{ name: 'b' }, { name: 'a' }] });
+    const route = createModernRouter({ serverInfo, dispatch });
+
+    const { status, body } = await route(
+      { jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta: modernMeta } },
+      {},
+    );
+
+    expect(status).toBe(200);
+    expect(dispatch).toHaveBeenCalledWith('tools/list', { _meta: modernMeta });
+    expect((body as any).result.resultType).toBe('complete');
+  });
+
+  it('stamps serverInfo into every result _meta', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ tools: [] });
+    const route = createModernRouter({ serverInfo, dispatch });
+
+    const { body } = await route(
+      { jsonrpc: '2.0', id: 3, method: 'tools/list', params: { _meta: modernMeta } },
+      {},
+    );
+
+    expect((body as any).result._meta['io.modelcontextprotocol/serverInfo']).toEqual(serverInfo);
+  });
+
+  it('rejects a header that disagrees with the body', async () => {
+    const dispatch = vi.fn();
+    const route = createModernRouter({ serverInfo, dispatch });
+
+    const { status, body } = await route(
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'a', _meta: modernMeta },
+      },
+      { 'mcp-method': 'tools/list' },
+    );
+
+    expect(status).toBe(400);
+    expect((body as any).error.code).toBe(-32020);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown protocol version with -32022', async () => {
+    const route = createModernRouter({ serverInfo, dispatch: vi.fn() });
+
+    const { status, body } = await route(
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/list',
+        params: { _meta: { 'io.modelcontextprotocol/protocolVersion': '2030-01-01' } },
+      },
+      {},
+    );
+
+    expect(status).toBe(400);
+    expect((body as any).error.code).toBe(-32022);
+  });
+
+  it('passes an input_required result through untouched', async () => {
+    const inputRequired = {
+      resultType: 'input_required',
+      inputRequests: [{ kind: 'elicitation', id: 'q1', params: {} }],
+      requestState: 'state-token',
+    };
+    const route = createModernRouter({
+      serverInfo,
+      dispatch: vi.fn().mockResolvedValue(inputRequired),
+    });
+
+    const { body } = await route(
+      { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { _meta: modernMeta } },
+      {},
+    );
+
+    expect((body as any).result.resultType).toBe('input_required');
+    expect((body as any).result.requestState).toBe('state-token');
+  });
+
+  it('surfaces a dispatch failure as a JSON-RPC internal error, not a throw', async () => {
+    const route = createModernRouter({
+      serverInfo,
+      dispatch: vi.fn().mockRejectedValue(new Error('downstream exploded')),
+    });
+
+    const { status, body } = await route(
+      { jsonrpc: '2.0', id: 7, method: 'tools/list', params: { _meta: modernMeta } },
+      {},
+    );
+
+    expect(status).toBe(500);
+    expect((body as any).error.code).toBe(-32603);
+    expect((body as any).id).toBe(7);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/router.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/router.js'`
+
+- [ ] **Step 3: Write the router**
+
+```ts
+// src/protocol/router.ts
+/**
+ * Request router for MCP 2026-07-28.
+ *
+ * Deliberately does NOT use the SDK's StreamableHTTPServerTransport: that
+ * transport is built around the initialize handshake and Mcp-Session-Id, both
+ * of which this revision removed. Legacy revisions keep using it (see
+ * resolveTransport in ../middleware.ts); this router serves only 2026 clients.
+ */
+
+import { detectRevision } from './detect.js';
+import { buildDiscoverResult, isDiscoverRequest } from './discover.js';
+import { validateMcpHeaders } from './headers.js';
+import { writeServerInfo, type Implementation } from './meta.js';
+import { isInputRequired, normalizeResultType } from './mrtr.js';
+import { ProtocolError } from './errors.js';
+import { JSON_RPC_ERROR_CODES } from '../constants.js';
+import { debugError } from '../debug-log.js';
+
+export interface ModernRouterOptions {
+  serverInfo: Implementation;
+  /** Executes an already-validated method against the aggregated backend. */
+  dispatch: (method: string, params: unknown) => Promise<Record<string, unknown>>;
+}
+
+export function createModernRouter(options: ModernRouterOptions) {
+  const { serverInfo, dispatch } = options;
+
+  return async function route(
+    body: unknown,
+    headers: Record<string, string | string[] | undefined>,
+  ): Promise<{ status: number; body: unknown }> {
+    const message = (body ?? {}) as Record<string, any>;
+    const id = message.id ?? null;
+
+    try {
+      // server/discover answers before version negotiation — it IS the
+      // negotiation, so it must not require a stated version.
+      if (isDiscoverRequest(body)) {
+        return {
+          status: 200,
+          body: { jsonrpc: '2.0', id, result: buildDiscoverResult(serverInfo) },
+        };
+      }
+
+      const { revision } = detectRevision(body, headers);
+      validateMcpHeaders(body, headers, revision);
+
+      const raw = await dispatch(message.method, message.params);
+
+      // input_required is a terminal shape; normalising it would erase the
+      // discriminator the client retries on.
+      const result = isInputRequired(raw) ? raw : normalizeResultType(raw);
+
+      return {
+        status: 200,
+        body: { jsonrpc: '2.0', id, result: writeServerInfo(result, serverInfo) },
+      };
+    } catch (error) {
+      if (error instanceof ProtocolError) {
+        return { status: 400, body: error.toJsonRpc(id) };
+      }
+
+      debugError('Modern router dispatch failed:', error);
+      return {
+        status: 500,
+        body: {
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: JSON_RPC_ERROR_CODES.INTERNAL_ERROR,
+            message: 'Internal server error',
+            ...(process.env.NODE_ENV === 'development' && {
+              data: error instanceof Error ? error.message : String(error),
+            }),
+          },
+        },
+      };
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/router.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Route 2026 traffic to the new router in `src/streamable-http.ts`**
+
+Add to the imports at the top of `src/streamable-http.ts`:
+
+```ts
+import { detectRevision } from './protocol/detect.js';
+import { createModernRouter } from './protocol/router.js';
+import { isDiscoverRequest } from './protocol/discover.js';
+import { ProtocolError } from './protocol/errors.js';
+```
+
+Inside `startStreamableHTTPServer`, immediately before `const mcpHandler = async (req: any, res: any) => {`, construct the router once:
+
+```ts
+  // 2026-07-28 clients are served by the hand-rolled protocol layer; every
+  // earlier revision keeps using the SDK transport below. Constructed once so
+  // the handle stores it owns survive across requests.
+  const modernRouter = createModernRouter({
+    serverInfo: { name: 'pluggedin-mcp', version: process.env.npm_package_version ?? '0.0.0' },
+    dispatch: async (method, params) =>
+      (await server.request({ method, params } as any, undefined as any)) as Record<string, unknown>,
+  });
+```
+
+Then, as the first statement inside the `try` of `mcpHandler`:
+
+```ts
+      // server/discover MUST answer without a handshake, and a 2026 client
+      // sends neither initialize nor a session header — so both are decided
+      // before any transport is resolved.
+      if (req.method === 'POST') {
+        let revision: string | undefined;
+        try {
+          revision = detectRevision(req.body, req.headers).revision;
+        } catch (error) {
+          if (error instanceof ProtocolError) {
+            return res.status(400).json(error.toJsonRpc(req.body?.id ?? null));
+          }
+          throw error;
+        }
+
+        if (revision === '2026-07-28' || isDiscoverRequest(req.body)) {
+          const { status, body } = await modernRouter(req.body, req.headers);
+          return res.status(status).json(body);
+        }
+      }
+```
+
+- [ ] **Step 6: Advertise the session header only to clients that use it**
+
+In `src/middleware.ts`, `corsMiddleware` currently always exposes `Mcp-Session-Id`. That is harmless but misleading now. Leave `Access-Control-Allow-Headers` untouched (legacy clients still send it) and leave `Access-Control-Expose-Headers` untouched (a 2026 client simply ignores it). **No change required** — recorded here so a reviewer does not "fix" it.
+
+In the same file, `versionMiddleware` rejects unsupported versions using `SUPPORTED_MCP_PROTOCOL_VERSIONS`, which Task 4 already widened to include `2026-07-28`. Change only the error code, from `JSON_RPC_ERROR_CODES.INVALID_REQUEST` to the spec-reserved one:
+
+```ts
+import { PROTOCOL_ERROR_CODES } from './protocol/errors.js';
+```
+
+```ts
+    if (version && !SUPPORTED_MCP_PROTOCOL_VERSIONS.includes(version as any)) {
+      return res.status(400).json({
+        jsonrpc: '2.0',
+        error: {
+          code: PROTOCOL_ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION,
+          message: `Unsupported MCP protocol version: ${version}. Supported: ${SUPPORTED_MCP_PROTOCOL_VERSIONS.join(', ')}`
+        },
+        id: null
+      });
+    }
+```
+
+- [ ] **Step 7: Run the whole suite to confirm legacy clients still work**
+
+Run: `npm test`
+Expected: PASS — in particular the pre-existing `tests/streamable-http.test.ts`. If a legacy test now fails, the detection precedence in Task 5 is wrong; fix `detect.ts`, not the test.
+
+- [ ] **Step 8: Verify against a real client**
+
+```bash
+npm run build
+npm run inspector:manual
+```
+
+Then, in a second terminal, confirm the stateless path answers with no handshake:
+
+```bash
+curl -sS -X POST http://localhost:8081/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"server/discover"}' | head -40
+```
+
+Expected: a JSON-RPC result whose `protocolVersions[0]` is `"2026-07-28"`, with **no** `Mcp-Session-Id` required and no prior `initialize`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/streamable-http.ts src/middleware.ts src/protocol/router.ts tests/protocol/router.test.ts
+git commit -m "feat(protocol): serve 2026-07-28 clients through the stateless router"
+```
+
+---
+
+# Phase B — Downstream bridging (pluggedin-mcp, south side)
+
+## Task 12: Downstream revision registry and probe
+
+The hub connects to N servers, each on its own revision. Before it can lower a canonical request onto a specific server it must know what that server speaks. The probe tries `server/discover` first (free and handshake-less on 2026 servers) and falls back to `initialize`.
+
+**Files:**
+- Create: `src/protocol/registry.ts`
+- Test: `tests/protocol/registry.test.ts`
+
+**Interfaces:**
+- Consumes: `Revision`, `isRevision`, `capabilitiesFor` from `versions.js`.
+- Produces:
+  - `interface DownstreamProfile { revision: Revision; capabilities: Record<string, unknown>; serverInfo?: Implementation; probedAt: number }`
+  - `type ProbeFn = (method: 'server/discover' | 'initialize', params?: unknown) => Promise<Record<string, unknown>>`
+  - `class DownstreamRegistry { probe(serverUuid: string, call: ProbeFn): Promise<DownstreamProfile>; get(serverUuid: string): DownstreamProfile | undefined; invalidate(serverUuid: string): void }`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/registry.test.ts
+import { describe, expect, it, vi } from 'vitest';
+import { DownstreamRegistry } from '../../src/protocol/registry.js';
+
+describe('downstream revision probing', () => {
+  it('prefers server/discover and records the newest mutually supported revision', async () => {
+    const registry = new DownstreamRegistry();
+    const call = vi.fn().mockResolvedValue({
+      protocolVersions: ['2026-07-28', '2025-11-25'],
+      capabilities: { tools: { listChanged: true } },
+      serverInfo: { name: 'modern-server', version: '1.0.0' },
+    });
+
+    const profile = await registry.probe('uuid-1', call);
+
+    expect(call).toHaveBeenCalledWith('server/discover', undefined);
+    expect(profile.revision).toBe('2026-07-28');
+    expect(profile.serverInfo).toEqual({ name: 'modern-server', version: '1.0.0' });
+  });
+
+  it('falls back to initialize when server/discover is unimplemented', async () => {
+    const registry = new DownstreamRegistry();
+    const call = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Method not found'))
+      .mockResolvedValueOnce({
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        serverInfo: { name: 'old-server', version: '0.1.0' },
+      });
+
+    const profile = await registry.probe('uuid-2', call);
+
+    expect(call).toHaveBeenNthCalledWith(1, 'server/discover', undefined);
+    expect(call).toHaveBeenNthCalledWith(2, 'initialize', expect.anything());
+    expect(profile.revision).toBe('2024-11-05');
+  });
+
+  it('ignores revisions the proxy does not know', async () => {
+    const registry = new DownstreamRegistry();
+    const call = vi.fn().mockResolvedValue({
+      protocolVersions: ['2099-01-01', '2025-06-18'],
+      capabilities: {},
+    });
+
+    expect((await registry.probe('uuid-3', call)).revision).toBe('2025-06-18');
+  });
+
+  it('defaults to the oldest revision when a server advertises nothing usable', async () => {
+    const registry = new DownstreamRegistry();
+    const call = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Method not found'))
+      .mockResolvedValueOnce({ capabilities: {} });
+
+    expect((await registry.probe('uuid-4', call)).revision).toBe('2024-11-05');
+  });
+
+  it('caches the profile and does not re-probe', async () => {
+    const registry = new DownstreamRegistry();
+    const call = vi.fn().mockResolvedValue({ protocolVersions: ['2026-07-28'], capabilities: {} });
+
+    await registry.probe('uuid-5', call);
+    expect(registry.get('uuid-5')?.revision).toBe('2026-07-28');
+
+    await registry.probe('uuid-5', call);
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-probes after invalidation', async () => {
+    const registry = new DownstreamRegistry();
+    const call = vi.fn().mockResolvedValue({ protocolVersions: ['2026-07-28'], capabilities: {} });
+
+    await registry.probe('uuid-6', call);
+    registry.invalidate('uuid-6');
+    expect(registry.get('uuid-6')).toBeUndefined();
+
+    await registry.probe('uuid-6', call);
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/registry.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/registry.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/registry.ts
+/**
+ * Per-downstream-server protocol profile.
+ *
+ * The hub aggregates servers that are each on their own revision, so "what
+ * does the proxy speak" is the wrong question — the right one is "what does
+ * THIS server speak". server/discover is the cheap path (no handshake, and the
+ * spec explicitly blesses it as a backward-compatibility probe); initialize is
+ * the fallback for everything older.
+ */
+
+import { compareRevisions, isRevision, REVISIONS, type Revision } from './versions.js';
+import type { Implementation } from './meta.js';
+
+/** Oldest revision still in wide deployment; the safest possible assumption. */
+const FLOOR_REVISION: Revision = '2024-11-05';
+
+export interface DownstreamProfile {
+  revision: Revision;
+  capabilities: Record<string, unknown>;
+  serverInfo?: Implementation;
+  probedAt: number;
+}
+
+export type ProbeFn = (
+  method: 'server/discover' | 'initialize',
+  params?: unknown,
+) => Promise<Record<string, unknown>>;
+
+function newestKnown(candidates: unknown): Revision | undefined {
+  if (!Array.isArray(candidates)) return undefined;
+  const known = candidates.filter(isRevision);
+  if (known.length === 0) return undefined;
+  return known.sort(compareRevisions)[known.length - 1];
+}
+
+export class DownstreamRegistry {
+  private readonly profiles = new Map<string, DownstreamProfile>();
+
+  get(serverUuid: string): DownstreamProfile | undefined {
+    return this.profiles.get(serverUuid);
+  }
+
+  invalidate(serverUuid: string): void {
+    this.profiles.delete(serverUuid);
+  }
+
+  async probe(serverUuid: string, call: ProbeFn): Promise<DownstreamProfile> {
+    const cached = this.profiles.get(serverUuid);
+    if (cached) return cached;
+
+    let profile: DownstreamProfile;
+
+    try {
+      const discovered = await call('server/discover', undefined);
+      profile = {
+        revision: newestKnown(discovered.protocolVersions) ?? FLOOR_REVISION,
+        capabilities: (discovered.capabilities as Record<string, unknown>) ?? {},
+        serverInfo: discovered.serverInfo as Implementation | undefined,
+        probedAt: Date.now(),
+      };
+    } catch {
+      // Pre-2026 server: server/discover does not exist. Fall back to the
+      // handshake, offering the newest revision the SDK transport can speak.
+      const initialized = await call('initialize', {
+        protocolVersion: REVISIONS[REVISIONS.length - 2],
+        capabilities: {},
+        clientInfo: { name: 'pluggedin-mcp', version: '0.0.0' },
+      });
+      const stated = initialized.protocolVersion;
+      profile = {
+        revision: isRevision(stated) ? stated : FLOOR_REVISION,
+        capabilities: (initialized.capabilities as Record<string, unknown>) ?? {},
+        serverInfo: initialized.serverInfo as Implementation | undefined,
+        probedAt: Date.now(),
+      };
+    }
+
+    this.profiles.set(serverUuid, profile);
+    return profile;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/registry.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/registry.ts tests/protocol/registry.test.ts
+git commit -m "feat(protocol): probe and record each downstream server's revision"
+```
+
+---
+
+## Task 13: Lowering — canonical requests onto a target revision
+
+The mirror of Task 5. Given a canonical (2026-shaped) request and a target revision, produce the wire form that revision understands: strip `_meta` keys it will not recognise, re-add `initialize` expectations, and translate `subscriptions/listen` back into `resources/subscribe`.
+
+**Files:**
+- Create: `src/protocol/lower.ts`
+- Test: `tests/protocol/lower.test.ts`
+
+**Interfaces:**
+- Consumes: `Revision`, `capabilitiesFor` from `versions.js`; `META_KEYS` from `meta.js`; `CacheableResult` from `cache.js`.
+- Produces:
+  - `function lowerRequest(method: string, params: Record<string, unknown> | undefined, target: Revision): { method: string; params: Record<string, unknown> | undefined }`
+  - `function lowerResult<T extends object>(result: T, target: Revision): Record<string, unknown>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/protocol/lower.test.ts
+import { describe, expect, it } from 'vitest';
+import { lowerRequest, lowerResult } from '../../src/protocol/lower.js';
+
+const modernMeta = {
+  'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+  'io.modelcontextprotocol/clientInfo': { name: 'claude', version: '1' },
+  progressToken: 'p1',
+};
+
+describe('lowering requests to a legacy target', () => {
+  it('strips 2026-only _meta keys a legacy server would not understand', () => {
+    const { params } = lowerRequest('tools/list', { _meta: modernMeta }, '2024-11-05');
+    expect(params?._meta).toEqual({ progressToken: 'p1' });
+  });
+
+  it('drops _meta entirely when nothing survives the strip', () => {
+    const { params } = lowerRequest(
+      'tools/list',
+      { _meta: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' } },
+      '2024-11-05',
+    );
+    expect(params).toEqual({});
+  });
+
+  it('leaves _meta untouched for a 2026 target', () => {
+    const { params } = lowerRequest('tools/list', { _meta: modernMeta }, '2026-07-28');
+    expect(params?._meta).toEqual(modernMeta);
+  });
+
+  it('translates subscriptions/listen back to resources/subscribe', () => {
+    const lowered = lowerRequest(
+      'subscriptions/listen',
+      { subscriptions: ['resourceSubscriptions'], uri: 'file:///a' },
+      '2025-11-25',
+    );
+    expect(lowered.method).toBe('resources/subscribe');
+    expect(lowered.params).toEqual({ uri: 'file:///a' });
+  });
+
+  it('leaves subscriptions/listen alone for a 2026 target', () => {
+    const lowered = lowerRequest('subscriptions/listen', { subscriptions: [] }, '2026-07-28');
+    expect(lowered.method).toBe('subscriptions/listen');
+  });
+
+  it('preserves non-meta params verbatim', () => {
+    const { params } = lowerRequest(
+      'tools/call',
+      { name: 'search', arguments: { q: 'x' }, _meta: modernMeta },
+      '2025-06-18',
+    );
+    expect(params?.name).toBe('search');
+    expect(params?.arguments).toEqual({ q: 'x' });
+  });
+});
+
+describe('lowering results to a legacy target', () => {
+  it('strips resultType and cache fields a legacy client would reject', () => {
+    const lowered = lowerResult(
+      { resultType: 'complete', ttlMs: 60_000, cacheScope: 'public', tools: [] },
+      '2024-11-05',
+    );
+    expect(lowered.resultType).toBeUndefined();
+    expect(lowered.ttlMs).toBeUndefined();
+    expect(lowered.cacheScope).toBeUndefined();
+    expect(lowered.tools).toEqual([]);
+  });
+
+  it('keeps them for a 2026 target', () => {
+    const lowered = lowerResult(
+      { resultType: 'complete', ttlMs: 60_000, cacheScope: 'public', tools: [] },
+      '2026-07-28',
+    );
+    expect(lowered.resultType).toBe('complete');
+    expect(lowered.ttlMs).toBe(60_000);
+  });
+
+  it('strips serverInfo from _meta for a legacy target but keeps other keys', () => {
+    const lowered = lowerResult(
+      {
+        resultType: 'complete',
+        _meta: {
+          'io.modelcontextprotocol/serverInfo': { name: 'x', version: '1' },
+          custom: 'keep',
+        },
+      },
+      '2024-11-05',
+    );
+    expect((lowered._meta as any)['io.modelcontextprotocol/serverInfo']).toBeUndefined();
+    expect((lowered._meta as any).custom).toBe('keep');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- tests/protocol/lower.test.ts`
+Expected: FAIL — `Cannot find module '../../src/protocol/lower.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/protocol/lower.ts
+/**
+ * Lowering: canonical (2026-shaped) messages → a specific target revision.
+ *
+ * Used in two places: sending a request down to a legacy downstream server, and
+ * sending a result back up to a legacy client. Both directions must remove
+ * fields the target does not know, because strict clients and servers reject
+ * unrecognised top-level result fields.
+ */
+
+import { capabilitiesFor, type Revision } from './versions.js';
+import { META_KEYS } from './meta.js';
+
+/** _meta keys introduced by 2026-07-28; meaningless to anything older. */
+const MODERN_META_KEYS: readonly string[] = [
+  META_KEYS.protocolVersion,
+  META_KEYS.clientCapabilities,
+  META_KEYS.clientInfo,
+  META_KEYS.serverInfo,
+  META_KEYS.logLevel,
+  META_KEYS.subscriptionId,
+];
+
+function stripModernMeta(meta: unknown): Record<string, unknown> | undefined {
+  if (!meta || typeof meta !== 'object') return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta as Record<string, unknown>)) {
+    if (!MODERN_META_KEYS.includes(key)) out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function lowerRequest(
+  method: string,
+  params: Record<string, unknown> | undefined,
+  target: Revision,
+): { method: string; params: Record<string, unknown> | undefined } {
+  const caps = capabilitiesFor(target);
+  if (caps.hasResultType) return { method, params };
+
+  let loweredMethod = method;
+  let loweredParams: Record<string, unknown> | undefined = params;
+
+  // subscriptions/listen replaced resources/subscribe in 2026; going back,
+  // the per-subscription opt-in list has no legacy equivalent and is dropped.
+  if (method === 'subscriptions/listen' && !caps.hasSubscriptionsListen) {
+    loweredMethod = 'resources/subscribe';
+    if (loweredParams) {
+      const { subscriptions: _subscriptions, ...rest } = loweredParams;
+      loweredParams = rest;
+    }
+  }
+
+  if (loweredParams && '_meta' in loweredParams) {
+    const { _meta, ...rest } = loweredParams;
+    const strippedMeta = stripModernMeta(_meta);
+    loweredParams = strippedMeta ? { ...rest, _meta: strippedMeta } : rest;
+  }
+
+  return { method: loweredMethod, params: loweredParams };
+}
+
+export function lowerResult<T extends object>(result: T, target: Revision): Record<string, unknown> {
+  if (capabilitiesFor(target).hasResultType) return result as Record<string, unknown>;
+
+  const {
+    resultType: _resultType,
+    ttlMs: _ttlMs,
+    cacheScope: _cacheScope,
+    _meta,
+    ...rest
+  } = result as Record<string, unknown>;
+
+  const strippedMeta = stripModernMeta(_meta);
+  return strippedMeta ? { ...rest, _meta: strippedMeta } : rest;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- tests/protocol/lower.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm test && npm run build
+git add src/protocol/lower.ts tests/protocol/lower.test.ts
+git commit -m "feat(protocol): lower canonical messages onto legacy target revisions"
+```
+
+---
+
+## Task 14: End-to-end bridge test
+
+Nothing so far proves the two directions compose. This task adds the test that would catch a regression in any of Tasks 1–13, exercising the two cases that matter commercially: a modern client driving a legacy server, and a legacy client driving a modern server.
+
+**Files:**
+- Create: `tests/protocol/bridge.test.ts`
+
+**Interfaces:**
+- Consumes: everything built so far. Produces no new source.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+// tests/protocol/bridge.test.ts
+import { describe, expect, it, vi } from 'vitest';
+import { createModernRouter } from '../../src/protocol/router.js';
+import { DownstreamRegistry } from '../../src/protocol/registry.js';
+import { lowerRequest, lowerResult } from '../../src/protocol/lower.js';
+import { MrtrCoordinator, toInputRequest, isInputRequired } from '../../src/protocol/mrtr.js';
+import { decorateCacheable, sortToolsDeterministically } from '../../src/protocol/cache.js';
+
+const serverInfo = { name: 'pluggedin-mcp', version: '2.3.0' };
+const modernMeta = { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' };
+
+describe('modern client → legacy downstream', () => {
+  it('serves a 2026 tools/list from a 2024-11-05 server, deterministically ordered and cacheable', async () => {
+    const registry = new DownstreamRegistry();
+    const probe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Method not found'))
+      .mockResolvedValueOnce({ protocolVersion: '2024-11-05', capabilities: {} });
+    const profile = await registry.probe('legacy-server', probe);
+    expect(profile.revision).toBe('2024-11-05');
+
+    // The legacy server returns an unordered list with no resultType and no
+    // cache fields — exactly what a 2024-11-05 server produces.
+    const downstream = vi.fn().mockResolvedValue({ tools: [{ name: 'zeta' }, { name: 'alpha' }] });
+
+    const route = createModernRouter({
+      serverInfo,
+      dispatch: async (method, params) => {
+        const lowered = lowerRequest(method, params as any, profile.revision);
+        expect(lowered.params?._meta).toBeUndefined();
+        const raw = await downstream(lowered.method, lowered.params);
+        return decorateCacheable(
+          { ...raw, tools: sortToolsDeterministically(raw.tools) },
+          { ttlMs: 60_000, cacheScope: 'public' },
+        );
+      },
+    });
+
+    const { status, body } = await route(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: modernMeta } },
+      {},
+    );
+
+    expect(status).toBe(200);
+    const result = (body as any).result;
+    expect(result.resultType).toBe('complete');
+    expect(result.ttlMs).toBe(60_000);
+    expect(result.cacheScope).toBe('public');
+    expect(result.tools.map((t: any) => t.name)).toEqual(['alpha', 'zeta']);
+    expect(result._meta['io.modelcontextprotocol/serverInfo']).toEqual(serverInfo);
+  });
+
+  it('converts a legacy elicitation into an MRTR round trip and resumes it', async () => {
+    const coordinator = new MrtrCoordinator<{ method: string; params: unknown }>();
+
+    // First call: the legacy server wants input, so the hub parks the call.
+    const parked = coordinator.park(
+      { method: 'tools/call', params: { name: 'deploy' } },
+      [toInputRequest('elicitation/create', 'q1', { message: 'Which environment?' })],
+    );
+
+    const route = createModernRouter({
+      serverInfo,
+      dispatch: async () => parked as unknown as Record<string, unknown>,
+    });
+
+    const first = await route(
+      { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { _meta: modernMeta } },
+      {},
+    );
+    const firstResult = (first.body as any).result;
+    expect(isInputRequired(firstResult)).toBe(true);
+    expect(firstResult.inputRequests[0].kind).toBe('elicitation');
+
+    // Retry: the client answers, the hub finds the parked call and replays it.
+    const resumed = coordinator.resume(firstResult.requestState, [
+      { id: 'q1', result: { action: 'accept', content: { env: 'staging' } } },
+    ]);
+    expect(resumed?.parked).toEqual({ method: 'tools/call', params: { name: 'deploy' } });
+    expect((resumed?.responses.get('q1')?.result as any).content).toEqual({ env: 'staging' });
+  });
+});
+
+describe('legacy client → modern downstream', () => {
+  it('strips 2026-only result fields so a 2024-11-05 client can parse it', () => {
+    const modernResult = {
+      resultType: 'complete' as const,
+      ttlMs: 60_000,
+      cacheScope: 'public' as const,
+      tools: [{ name: 'alpha' }],
+      _meta: {
+        'io.modelcontextprotocol/serverInfo': serverInfo,
+        progressToken: 'p1',
+      },
+    };
+
+    const lowered = lowerResult(modernResult, '2024-11-05');
+
+    expect(lowered.resultType).toBeUndefined();
+    expect(lowered.ttlMs).toBeUndefined();
+    expect(lowered.cacheScope).toBeUndefined();
+    expect((lowered._meta as any)['io.modelcontextprotocol/serverInfo']).toBeUndefined();
+    expect((lowered._meta as any).progressToken).toBe('p1');
+    expect(lowered.tools).toEqual([{ name: 'alpha' }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npm test -- tests/protocol/bridge.test.ts`
+Expected: PASS, 3 tests. If any fail, the defect is in the module under test, not in this file — fix the module.
+
+- [ ] **Step 3: Run the full suite and commit**
+
+```bash
+npm test && npm run build
+git add tests/protocol/bridge.test.ts
+git commit -m "test(protocol): cover modern↔legacy bridging end to end"
+```
+
+---
+
+# Phase C — pluggedin-app alignment
+
+All Phase C work happens in `/Users/cem/Mns/pluggedin-app` on its own branch. Create it first:
+
+```bash
+cd /Users/cem/Mns/pluggedin-app
+git checkout -b feature/mcp-2026-07-28-alignment
+```
+
+## Task 15: Replace the four hardcoded `2024-11-05` sites
+
+The app pins the *first* MCP revision in four places. Two are outbound client headers, two are `initialize` params. All four must read from one table.
+
+**Files:**
+- Create: `lib/mcp/protocol/versions.ts`
+- Modify: `lib/mcp/client-wrapper.ts:860`, `lib/mcp/streamable-http/handler.ts:263`, `app/actions/trigger-mcp-oauth.ts:365`, `app/actions/test-mcp-connection.ts:251`, `package.json`
+- Test: `tests/lib/mcp-protocol-versions.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Revision` and `REVISIONS` — identical values to the proxy's registry
+  - `const CLIENT_PROTOCOL_VERSION: Revision` — what the app sends when acting as an MCP *client* (`'2025-11-25'`, the newest the pinned SDK can speak)
+  - `const ADVERTISED_PROTOCOL_VERSION: Revision` — what the app advertises when acting as an MCP *server* (`'2026-07-28'`)
+
+The two constants differ on purpose: the app's outbound client is the SDK, which cannot speak 2026 yet, while its inbound endpoint is bridged by pluggedin-mcp and can.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/lib/mcp-protocol-versions.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  ADVERTISED_PROTOCOL_VERSION,
+  CLIENT_PROTOCOL_VERSION,
+  REVISIONS,
+} from '@/lib/mcp/protocol/versions';
+
+describe('app protocol version constants', () => {
+  it('no longer pins the first-ever revision', () => {
+    expect(CLIENT_PROTOCOL_VERSION).not.toBe('2024-11-05');
+  });
+
+  it('sends the newest revision the pinned SDK can speak', () => {
+    expect(CLIENT_PROTOCOL_VERSION).toBe('2025-11-25');
+  });
+
+  it('advertises 2026-07-28 on the inbound endpoint', () => {
+    expect(ADVERTISED_PROTOCOL_VERSION).toBe('2026-07-28');
+  });
+
+  it('agrees with the proxy registry on the full revision list', () => {
+    expect(REVISIONS).toEqual([
+      '2024-10-07',
+      '2024-11-05',
+      '2025-03-26',
+      '2025-06-18',
+      '2025-11-25',
+      '2026-07-28',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test tests/lib/mcp-protocol-versions.test.ts`
+Expected: FAIL — cannot resolve `@/lib/mcp/protocol/versions`
+
+- [ ] **Step 3: Write the module**
+
+```ts
+// lib/mcp/protocol/versions.ts
+/**
+ * MCP protocol revisions, as seen by pluggedin-app.
+ *
+ * Mirrors pluggedin-mcp/src/protocol/versions.ts. Kept as a small local copy
+ * rather than a shared package because the app needs the constants, not the
+ * bridge — and a cross-repo dependency for six string literals is worse than
+ * the duplication. The test asserts the two lists stay in agreement.
+ */
+
+export type Revision =
+  | '2024-10-07'
+  | '2024-11-05'
+  | '2025-03-26'
+  | '2025-06-18'
+  | '2025-11-25'
+  | '2026-07-28';
+
+export const REVISIONS: readonly Revision[] = [
+  '2024-10-07',
+  '2024-11-05',
+  '2025-03-26',
+  '2025-06-18',
+  '2025-11-25',
+  '2026-07-28',
+] as const;
+
+/**
+ * Sent when the app acts as an MCP CLIENT against a downstream server.
+ *
+ * Capped at 2025-11-25 because that is the newest revision the pinned
+ * @modelcontextprotocol/sdk (1.30.0) implements — the app's outbound path is
+ * the SDK's, not the hand-rolled bridge's.
+ */
+export const CLIENT_PROTOCOL_VERSION: Revision = '2025-11-25';
+
+/**
+ * Advertised when the app acts as an MCP SERVER on /api/mcp. Inbound requests
+ * are bridged by pluggedin-mcp, which does speak 2026-07-28.
+ */
+export const ADVERTISED_PROTOCOL_VERSION: Revision = '2026-07-28';
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test tests/lib/mcp-protocol-versions.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Replace all four hardcoded sites**
+
+In `lib/mcp/client-wrapper.ts`, add to the imports:
+
+```ts
+import { CLIENT_PROTOCOL_VERSION } from '@/lib/mcp/protocol/versions';
+```
+
+and change line 860 from `'MCP-Protocol-Version': '2024-11-05'` to:
+
+```ts
+          'MCP-Protocol-Version': CLIENT_PROTOCOL_VERSION
+```
+
+In `lib/mcp/streamable-http/handler.ts`, add the same import and change line 263 from `protocolVersion: '2024-11-05',` to:
+
+```ts
+          protocolVersion: CLIENT_PROTOCOL_VERSION,
+```
+
+In `app/actions/trigger-mcp-oauth.ts`, add the same import and change line 365 identically.
+
+In `app/actions/test-mcp-connection.ts`, add the same import and change line 251 identically.
+
+- [ ] **Step 6: Verify no hardcoded revision survives**
+
+Run:
+
+```bash
+grep -rn "2024-11-05" --include="*.ts" --include="*.tsx" lib app | grep -v "protocol/versions.ts"
+```
+
+Expected: no output. If a line appears, replace it the same way.
+
+- [ ] **Step 7: Pin the SDK to match the proxy**
+
+In `package.json`, change `"@modelcontextprotocol/sdk": "^1.27.1"` to:
+
+```json
+"@modelcontextprotocol/sdk": "1.30.0"
+```
+
+Run `pnpm install`.
+
+- [ ] **Step 8: Run the suite and commit**
+
+```bash
+pnpm test
+pnpm lint
+git add package.json pnpm-lock.yaml lib/mcp/protocol/versions.ts lib/mcp/client-wrapper.ts lib/mcp/streamable-http/handler.ts app/actions/trigger-mcp-oauth.ts app/actions/test-mcp-connection.ts tests/lib/mcp-protocol-versions.test.ts
+git commit -m "fix(mcp): replace hardcoded 2024-11-05 with a single revision table and pin SDK 1.30.0"
+```
+
+---
+
+## Task 16: Stop rejecting stateless requests on `/api/mcp`
+
+Three call sites hard-require `Mcp-Session-Id`. A 2026-07-28 client sends none, so it currently gets a 400 on its first real call. This task makes the header optional without weakening anything for legacy clients.
+
+**Files:**
+- Modify: `app/api/mcp/route.ts:19-65` (POST), `:68-129` (GET), `:132-167` (DELETE); `lib/mcp/streamable-http/handler.ts:38-58`
+- Test: `tests/integration/streamable-http-stateless.test.ts`
+
+**Interfaces:**
+- Consumes: `ADVERTISED_PROTOCOL_VERSION` from `@/lib/mcp/protocol/versions`.
+- Produces: `handleStreamableHTTPRequest` gains the behaviour that a POST with no session id and no `initialize` is treated as a stateless request rather than an error.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/integration/streamable-http-stateless.test.ts
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/mcp/sessions/SessionManager', () => ({
+  getSessionManager: () => ({
+    getSession: vi.fn().mockResolvedValue(null),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/app/actions/mcp-servers', () => ({
+  getMcpServerByUuid: vi.fn().mockResolvedValue(null),
+}));
+
+import { handleStreamableHTTPRequest } from '@/lib/mcp/streamable-http/handler';
+
+const modernMeta = { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' };
+
+describe('stateless requests on /api/mcp', () => {
+  it('does not reject a POST that has no session id and no initialize', async () => {
+    const result = await handleStreamableHTTPRequest({
+      method: 'POST',
+      sessionId: null,
+      userId: 'user-1',
+      body: { jsonrpc: '2.0', id: 1, method: 'server/discover' },
+      headers: {},
+    });
+
+    expect(result.status).not.toBe(400);
+    expect(result.body?.error?.message).not.toMatch(/Missing Mcp-Session-Id/);
+  });
+
+  it('answers server/discover without any session', async () => {
+    const result = await handleStreamableHTTPRequest({
+      method: 'POST',
+      sessionId: null,
+      userId: 'user-1',
+      body: { jsonrpc: '2.0', id: 1, method: 'server/discover' },
+      headers: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.body.result.protocolVersions).toContain('2026-07-28');
+  });
+
+  it('still rejects a legacy non-initialize POST that claims a session it does not have', async () => {
+    const result = await handleStreamableHTTPRequest({
+      method: 'POST',
+      sessionId: 'expired-session',
+      userId: 'user-1',
+      body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      headers: {},
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error.message).toMatch(/Invalid or expired session/);
+  });
+
+  it('routes a stateless tools/list without minting a session', async () => {
+    const result = await handleStreamableHTTPRequest({
+      method: 'POST',
+      sessionId: null,
+      userId: 'user-1',
+      body: { jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta: modernMeta } },
+      headers: {},
+    });
+
+    expect(result.sessionId).toBeUndefined();
+    expect(result.body?.error?.code).not.toBe(-32600);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test tests/integration/streamable-http-stateless.test.ts`
+Expected: FAIL — the first test gets `status: 400` and `Missing Mcp-Session-Id header`.
+
+- [ ] **Step 3: Add stateless handling to the handler**
+
+In `lib/mcp/streamable-http/handler.ts`, add to the imports:
+
+```ts
+import { ADVERTISED_PROTOCOL_VERSION, REVISIONS } from '@/lib/mcp/protocol/versions';
+```
+
+Replace the block currently at lines 38–58 (from `if (options.method === 'POST') {` through the closing brace of the missing-session-id error) with:
+
+```ts
+    // Handle POST requests (JSON-RPC messages)
+    if (options.method === 'POST') {
+      // If no session ID, this might be an initialize request
+      if (!options.sessionId && options.body?.method === 'initialize') {
+        return handleInitializeRequest(options);
+      }
+
+      // server/discover is mandatory under 2026-07-28 and MUST answer with no
+      // handshake, no session and no prior state — clients call it first,
+      // precisely to find out what this endpoint speaks.
+      if (options.body?.method === 'server/discover') {
+        return {
+          success: true,
+          status: 200,
+          body: {
+            jsonrpc: '2.0',
+            id: options.body?.id ?? null,
+            result: {
+              resultType: 'complete',
+              protocolVersions: [...REVISIONS].reverse(),
+              capabilities: {
+                tools: { listChanged: true },
+                resources: { listChanged: true, subscribe: true },
+                prompts: { listChanged: true },
+              },
+              serverInfo: { name: 'pluggedin-app', version: process.env.npm_package_version ?? '0.0.0' },
+            },
+          },
+        };
+      }
+
+      // A 2026-07-28 client is stateless: it sends neither initialize nor a
+      // session id, carrying its protocol version in params._meta instead.
+      // Rejecting that as "missing session" is what breaks modern clients.
+      const statesItsOwnVersion = Boolean(
+        options.body?.params?._meta?.['io.modelcontextprotocol/protocolVersion'],
+      );
+
+      if (!options.sessionId && statesItsOwnVersion) {
+        return routeStatelessRequest(options);
+      }
+
+      if (!options.sessionId) {
+        return {
+          success: false,
+          status: 400,
+          body: {
+            jsonrpc: '2.0',
+            error: {
+              code: -32600,
+              message: 'Missing Mcp-Session-Id header',
+            },
+            id: options.body?.id || null,
+          },
+        };
+      }
+```
+
+Then add this function at the end of the file, beside `handleInitializeRequest`:
+
+```ts
+/**
+ * Routes a stateless (2026-07-28) request.
+ *
+ * There is no session to look up: the request self-describes and any instance
+ * can serve it. Cross-call state, where a tool needs it, travels as an explicit
+ * server-minted handle in the tool arguments rather than as ambient session
+ * state — see pluggedin-mcp/src/protocol/handles.ts.
+ */
+async function routeStatelessRequest(
+  options: StreamableHTTPRequestOptions,
+): Promise<StreamableHTTPResponse> {
+  const method = options.body?.method;
+  const id = options.body?.id ?? null;
+
+  if (typeof method !== 'string') {
+    return {
+      success: false,
+      status: 400,
+      body: { jsonrpc: '2.0', id, error: { code: -32600, message: 'Missing method' } },
+    };
+  }
+
+  return {
+    success: true,
+    status: 200,
+    body: {
+      jsonrpc: '2.0',
+      id,
+      result: {
+        resultType: 'complete',
+        _meta: {
+          'io.modelcontextprotocol/serverInfo': {
+            name: 'pluggedin-app',
+            version: process.env.npm_package_version ?? '0.0.0',
+          },
+          'io.modelcontextprotocol/protocolVersion': ADVERTISED_PROTOCOL_VERSION,
+        },
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Make the session header optional on GET and DELETE**
+
+In `app/api/mcp/route.ts`, replace the GET guard at lines 71–78 with:
+
+```ts
+    // 2026-07-28 removed the HTTP GET endpoint in favour of subscriptions/listen,
+    // and removed Mcp-Session-Id entirely. A GET with no session is therefore a
+    // legacy client that never initialised — still an error, but say so
+    // accurately rather than blaming a header the spec deleted.
+    const sessionId = req.headers.get('Mcp-Session-Id');
+
+    if (!sessionId) {
+      return NextResponse.json(
+        {
+          error: 'SSE streaming requires an initialised session. Clients on MCP 2026-07-28 should use subscriptions/listen over POST instead.',
+        },
+        { status: 400 }
+      );
+    }
+```
+
+Replace the DELETE guard at lines 135–142 with:
+
+```ts
+    // Under 2026-07-28 there is no session to terminate, so a DELETE without a
+    // session id is a no-op success rather than a client error.
+    const sessionId = req.headers.get('Mcp-Session-Id');
+
+    if (!sessionId) {
+      const corsHeaders = getCorsHeaders(req);
+      return NextResponse.json(
+        { success: true, message: 'No session to terminate (stateless request)' },
+        { headers: corsHeaders }
+      );
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm test tests/integration/streamable-http-stateless.test.ts tests/integration/streamable-http.test.ts`
+Expected: PASS. The pre-existing `streamable-http.test.ts` must still pass unchanged — it covers the legacy path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+pnpm test && pnpm lint
+git add app/api/mcp/route.ts lib/mcp/streamable-http/handler.ts tests/integration/streamable-http-stateless.test.ts
+git commit -m "feat(mcp): accept stateless 2026-07-28 requests on /api/mcp"
+```
+
+---
+
+## Task 17: Confine `StreamableHTTPWrapper` to the legacy path
+
+`lib/mcp/transports/StreamableHTTPWrapper.ts` is 451 lines whose entire purpose is capturing `Mcp-Session-Id` through CORS — a header 2026-07-28 deleted. It must stay for legacy downstream servers, but must not run when the downstream is modern, and the code should say so.
+
+**Files:**
+- Modify: `lib/mcp/transports/StreamableHTTPWrapper.ts` (header comment + one guard), `lib/security/cors.ts:44-45`
+- Test: `tests/lib/streamable-http-wrapper-legacy.test.ts`
+
+**Interfaces:**
+- Consumes: `CLIENT_PROTOCOL_VERSION` from `@/lib/mcp/protocol/versions`.
+- Produces: `StreamableHTTPWrapper` gains `readonly isLegacyOnly = true` and skips session capture when constructed with `{ statelessDownstream: true }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/lib/streamable-http-wrapper-legacy.test.ts
+import { describe, expect, it } from 'vitest';
+import { StreamableHTTPWrapper } from '@/lib/mcp/transports/StreamableHTTPWrapper';
+
+describe('StreamableHTTPWrapper scope', () => {
+  it('declares itself legacy-only', () => {
+    expect(StreamableHTTPWrapper.prototype.isLegacyOnly).toBe(true);
+  });
+
+  it('skips session capture when the downstream is stateless', () => {
+    const wrapper = new StreamableHTTPWrapper(
+      new URL('https://example.test/mcp'),
+      { statelessDownstream: true },
+    );
+    expect(wrapper.capturesSessionId).toBe(false);
+  });
+
+  it('captures session ids for a legacy downstream', () => {
+    const wrapper = new StreamableHTTPWrapper(new URL('https://example.test/mcp'), {});
+    expect(wrapper.capturesSessionId).toBe(true);
+  });
+});
+```
+
+Adjust the constructor arguments in this test to match the wrapper's real signature — read `lib/mcp/transports/StreamableHTTPWrapper.ts` before writing it, and keep the three assertions.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test tests/lib/streamable-http-wrapper-legacy.test.ts`
+Expected: FAIL — `isLegacyOnly` and `capturesSessionId` do not exist.
+
+- [ ] **Step 3: Replace the file's header comment**
+
+Replace the existing header comment block (lines 1–20 or thereabouts) with:
+
+```ts
+/**
+ * StreamableHTTPWrapper — LEGACY TRANSPORT PATH ONLY.
+ *
+ * This wrapper exists to capture the Mcp-Session-Id response header through
+ * CORS, because a browser cannot read a response header the origin server did
+ * not name in Access-Control-Expose-Headers.
+ *
+ * MCP 2026-07-28 removed protocol-level sessions and the Mcp-Session-Id header
+ * outright, so none of this applies to a modern downstream server. Do not
+ * extend this file for new work: set statelessDownstream and let the request
+ * carry its own context in params._meta instead.
+ *
+ * Kept because downstream servers on 2024-11-05 … 2025-11-25 remain in wide
+ * deployment and the hub's whole value proposition is that they keep working.
+ */
+```
+
+- [ ] **Step 4: Add the guard**
+
+Add to the class body, near the other fields:
+
+```ts
+  /** Marks this transport as serving pre-2026 revisions only. */
+  readonly isLegacyOnly = true;
+
+  /** False when the downstream speaks 2026-07-28, which has no session header. */
+  readonly capturesSessionId: boolean;
+```
+
+In the constructor, immediately after the existing option assignments:
+
+```ts
+    this.capturesSessionId = options?.statelessDownstream !== true;
+```
+
+Add `statelessDownstream?: boolean;` to the wrapper's options interface.
+
+Then, in the fetch wrapper where the session id is read (around line 135, `const sessionId = response.headers.get('Mcp-Session-Id');`), guard it:
+
+```ts
+        // A 2026-07-28 downstream never sends this header; looking for it and
+        // warning when it is absent would produce noise on every request.
+        if (!this.capturesSessionId) return response;
+
+        const sessionId = response.headers.get('Mcp-Session-Id');
+```
+
+- [ ] **Step 5: Document the CORS headers as legacy**
+
+In `lib/security/cors.ts`, directly above lines 44–45, add:
+
+```ts
+    // Mcp-Session-Id is a pre-2026 header. It stays advertised because
+    // downstream servers and clients on 2024-11-05 … 2025-11-25 still use it;
+    // a 2026-07-28 client simply ignores both entries.
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm test tests/lib/streamable-http-wrapper-legacy.test.ts && pnpm test`
+Expected: PASS across the suite.
+
+- [ ] **Step 7: Commit**
+
+```bash
+pnpm lint
+git add lib/mcp/transports/StreamableHTTPWrapper.ts lib/security/cors.ts tests/lib/streamable-http-wrapper-legacy.test.ts
+git commit -m "refactor(mcp): confine session-capturing transport wrapper to legacy revisions"
+```
+
+---
+
+# Phase D — Authorization
+
+## Task 18: Client ID Metadata Documents, `iss` validation, `application_type`
+
+Three authorization changes land together because they touch the same OAuth client code: DCR (RFC 7591) is deprecated in favour of Client ID Metadata Documents; clients MUST validate a present `iss` (RFC 9207) before redeeming an authorization code; and DCR, where still used, MUST send an `application_type`.
+
+**Files:**
+- Create: `lib/mcp/oauth/ClientIdMetadata.ts`
+- Modify: `lib/mcp/oauth/OAuthStateManager.ts`
+- Test: `tests/oauth/client-id-metadata.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface ClientIdMetadataDocument { client_id: string; client_name: string; redirect_uris: string[]; application_type: 'web' | 'native'; token_endpoint_auth_method: string; grant_types: string[]; response_types: string[] }`
+  - `function buildClientIdMetadataDocument(opts: { clientIdUrl: string; clientName: string; redirectUris: string[]; applicationType?: 'web' | 'native' }): ClientIdMetadataDocument`
+  - `function validateIssuer(params: { iss?: string; recordedIssuer: string }): void` — throws when a present `iss` disagrees
+  - `function credentialKey(issuer: string, clientId: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/oauth/client-id-metadata.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  buildClientIdMetadataDocument,
+  credentialKey,
+  validateIssuer,
+} from '@/lib/mcp/oauth/ClientIdMetadata';
+
+describe('Client ID Metadata Documents', () => {
+  it('uses the document URL as the client_id', () => {
+    const doc = buildClientIdMetadataDocument({
+      clientIdUrl: 'https://plugged.in/.well-known/mcp-client',
+      clientName: 'Plugged.in',
+      redirectUris: ['https://plugged.in/api/oauth/callback'],
+    });
+    expect(doc.client_id).toBe('https://plugged.in/.well-known/mcp-client');
+  });
+
+  it('always declares application_type to avoid OIDC redirect URI conflicts', () => {
+    const doc = buildClientIdMetadataDocument({
+      clientIdUrl: 'https://plugged.in/.well-known/mcp-client',
+      clientName: 'Plugged.in',
+      redirectUris: ['https://plugged.in/api/oauth/callback'],
+    });
+    expect(doc.application_type).toBe('web');
+
+    const native = buildClientIdMetadataDocument({
+      clientIdUrl: 'https://plugged.in/.well-known/mcp-client',
+      clientName: 'Plugged.in',
+      redirectUris: ['pluggedin://callback'],
+      applicationType: 'native',
+    });
+    expect(native.application_type).toBe('native');
+  });
+
+  it('rejects a non-https client id URL', () => {
+    expect(() =>
+      buildClientIdMetadataDocument({
+        clientIdUrl: 'http://plugged.in/.well-known/mcp-client',
+        clientName: 'Plugged.in',
+        redirectUris: ['https://plugged.in/cb'],
+      }),
+    ).toThrow(/https/i);
+  });
+
+  it('requires at least one redirect URI', () => {
+    expect(() =>
+      buildClientIdMetadataDocument({
+        clientIdUrl: 'https://plugged.in/.well-known/mcp-client',
+        clientName: 'Plugged.in',
+        redirectUris: [],
+      }),
+    ).toThrow(/redirect/i);
+  });
+});
+
+describe('RFC 9207 issuer validation', () => {
+  it('accepts a matching iss', () => {
+    expect(() =>
+      validateIssuer({ iss: 'https://auth.example', recordedIssuer: 'https://auth.example' }),
+    ).not.toThrow();
+  });
+
+  it('rejects a mismatched iss — this is the mix-up attack', () => {
+    expect(() =>
+      validateIssuer({ iss: 'https://evil.example', recordedIssuer: 'https://auth.example' }),
+    ).toThrow(/issuer/i);
+  });
+
+  it('accepts an absent iss, since the parameter is only SHOULD', () => {
+    expect(() => validateIssuer({ recordedIssuer: 'https://auth.example' })).not.toThrow();
+  });
+});
+
+describe('credential binding', () => {
+  it('keys credentials by issuer so they are never reused across servers', () => {
+    expect(credentialKey('https://auth-a.example', 'client-1')).not.toBe(
+      credentialKey('https://auth-b.example', 'client-1'),
+    );
+    expect(credentialKey('https://auth-a.example', 'client-1')).toBe(
+      credentialKey('https://auth-a.example', 'client-1'),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test tests/oauth/client-id-metadata.test.ts`
+Expected: FAIL — cannot resolve `@/lib/mcp/oauth/ClientIdMetadata`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// lib/mcp/oauth/ClientIdMetadata.ts
+/**
+ * OAuth client registration for MCP 2026-07-28.
+ *
+ * Three related changes:
+ *
+ * 1. Dynamic Client Registration (RFC 7591) is deprecated in favour of Client
+ *    ID Metadata Documents: the client_id IS an https URL that resolves to the
+ *    client's own metadata, so there is nothing to register and nothing to
+ *    expire. DCR stays available only for authorization servers that cannot do
+ *    CIMD yet.
+ * 2. Authorization servers SHOULD return iss (RFC 9207) and clients MUST
+ *    validate it before redeeming the code — this is the defence against the
+ *    authorization-server mix-up attack.
+ * 3. Client credentials are bound to the authorization server that issued
+ *    them: key by issuer, never reuse across issuers, re-register on change.
+ */
+
+export interface ClientIdMetadataDocument {
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+  application_type: 'web' | 'native';
+  token_endpoint_auth_method: string;
+  grant_types: string[];
+  response_types: string[];
+}
+
+export function buildClientIdMetadataDocument(opts: {
+  clientIdUrl: string;
+  clientName: string;
+  redirectUris: string[];
+  applicationType?: 'web' | 'native';
+}): ClientIdMetadataDocument {
+  if (!opts.clientIdUrl.startsWith('https://')) {
+    throw new Error('Client ID Metadata Document URL must use https');
+  }
+  if (opts.redirectUris.length === 0) {
+    throw new Error('At least one redirect URI is required');
+  }
+
+  return {
+    client_id: opts.clientIdUrl,
+    client_name: opts.clientName,
+    redirect_uris: opts.redirectUris,
+    // Required by SEP-837: without it, an OIDC provider may apply web
+    // redirect-URI rules to a native client (or vice versa) and reject it.
+    application_type: opts.applicationType ?? 'web',
+    token_endpoint_auth_method: 'none',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+  };
+}
+
+export function validateIssuer(params: { iss?: string; recordedIssuer: string }): void {
+  // iss is SHOULD, not MUST — absence is legal. A PRESENT but mismatched iss
+  // is an active mix-up attempt and must abort before the code is redeemed.
+  if (params.iss === undefined) return;
+  if (params.iss !== params.recordedIssuer) {
+    throw new Error(
+      `Authorization response issuer "${params.iss}" does not match the recorded issuer "${params.recordedIssuer}"`,
+    );
+  }
+}
+
+export function credentialKey(issuer: string, clientId: string): string {
+  return `${issuer}::${clientId}`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test tests/oauth/client-id-metadata.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Call `validateIssuer` from the state manager**
+
+Read `lib/mcp/oauth/OAuthStateManager.ts` and find where the authorization callback's state is verified and the code is about to be redeemed. Add before the redemption:
+
+```ts
+import { validateIssuer } from '@/lib/mcp/oauth/ClientIdMetadata';
+```
+
+```ts
+    // RFC 9207: reject a callback whose iss disagrees with the issuer recorded
+    // when the authorization request was created, BEFORE redeeming the code.
+    validateIssuer({ iss: callbackParams.iss, recordedIssuer: storedState.issuer });
+```
+
+If `storedState` has no `issuer` field, add one where the state is created, populated from the authorization server's discovered issuer. Persist it alongside the existing state fields — and if that requires a schema change, use `pnpm db:generate` then `pnpm db:migrate`. **Never** apply SQL directly.
+
+- [ ] **Step 6: Run the suite and commit**
+
+```bash
+pnpm test && pnpm lint
+git add lib/mcp/oauth/ClientIdMetadata.ts lib/mcp/oauth/OAuthStateManager.ts tests/oauth/client-id-metadata.test.ts
+git commit -m "feat(oauth): add Client ID Metadata Documents and RFC 9207 issuer validation"
+```
+
+---
+
+# Phase E — Documentation
+
+## Task 19: Compatibility matrix
+
+The bridge's value is only legible if someone can see what it bridges. This is the page that turns the engineering into a positioning claim.
+
+**Files:**
+- Create: `docs/PROTOCOL_COMPATIBILITY.md` (in pluggedin-mcp)
+- Modify: `README.md` (in pluggedin-mcp) — one link in the features list
+
+- [ ] **Step 1: Write the compatibility document**
+
+```markdown
+# MCP Protocol Compatibility
+
+pluggedin-mcp speaks every published MCP revision on both sides at once. A
+client on any revision can reach a server on any other revision through the hub.
+
+## Revisions
+
+| Revision | Client → hub | Hub → server | Notes |
+|---|---|---|---|
+| `2024-10-07` | ✅ | ✅ | Via SDK transport |
+| `2024-11-05` | ✅ | ✅ | Via SDK transport |
+| `2025-03-26` | ✅ | ✅ | Via SDK transport |
+| `2025-06-18` | ✅ | ✅ | Via SDK transport |
+| `2025-11-25` | ✅ | ✅ | Newest revision `@modelcontextprotocol/sdk` 1.30.0 implements |
+| `2026-07-28` | ✅ | ✅ | Hand-rolled; no released SDK implements it yet |
+
+## What the bridge translates
+
+| 2026-07-28 | Pre-2026 | How the hub bridges it |
+|---|---|---|
+| No `initialize` handshake | `initialize` + `notifications/initialized` | Hub performs the handshake downstream; modern clients never see it |
+| No `Mcp-Session-Id` | Session header required | Hub mints server-side handles for modern clients, keeps real sessions for legacy ones |
+| `server/discover` | Not present | Hub answers natively; probes downstream with `initialize` fallback |
+| `resultType` on every result | Absent | Added on the way up, stripped on the way down |
+| `ttlMs` / `cacheScope` | Absent | Hub computes the merged value: narrowest scope, shortest TTL |
+| MRTR `input_required` | `sampling` / `elicitation` / `roots` pushed at the client | Converted in both directions; correlation via `requestState` |
+| `subscriptions/listen` | HTTP GET + `resources/subscribe` | Translated per target revision |
+| `-32020` / `-32021` / `-32022` | Implementation-defined codes | Emitted for modern clients only |
+
+## Deprecated features
+
+Deprecated in 2026-07-28 with a minimum twelve-month removal window. The hub
+keeps them working for legacy peers and emulates them for modern ones.
+
+| Feature | Status | Migration |
+|---|---|---|
+| Sampling | Deprecated | Integrate an LLM provider directly. Plugged.in users can point at [pap-model-router](https://models.plugged.in), which is already OpenAI-compatible and multi-provider. |
+| Roots | Deprecated | Pass directories via tool parameters, resource URIs, or server config |
+| Logging | Deprecated | `stderr` on stdio, or OpenTelemetry — see the `traceparent` `_meta` key |
+| HTTP+SSE transport | Deprecated | Streamable HTTP |
+| DCR (RFC 7591) | Deprecated | Client ID Metadata Documents |
+| `includeContext: thisServer` / `allServers` | Deprecated | Omit, or use `none` |
+
+## Caveats
+
+- **SSE resumability is gone.** `Last-Event-ID` and SSE event IDs were removed:
+  a broken response stream loses the in-flight request and the client must
+  re-issue it with a new request ID. The hub does not retry on the client's
+  behalf — that would double-execute non-idempotent tool calls.
+- **`tasks/list` is gone.** Task inventory is the server's responsibility now.
+- **The SDK lags the spec.** `@modelcontextprotocol/sdk` 1.30.0 tops out at
+  `2025-11-25`. `tests/protocol/negotiation.test.ts` carries a deliberate
+  tripwire that fails when the SDK catches up, so the hand-rolled layer can be
+  re-evaluated at that point rather than silently diverging.
+```
+
+- [ ] **Step 2: Link it from the README**
+
+In `README.md`, add to the features list:
+
+```markdown
+- **Protocol version bridging** — one endpoint serving MCP `2024-10-07` through `2026-07-28`, in both directions. See [Protocol Compatibility](docs/PROTOCOL_COMPATIBILITY.md).
+```
+
+- [ ] **Step 3: Verify every claim in the table**
+
+For each row of "What the bridge translates", confirm a test exists that covers it:
+
+```bash
+npm test
+grep -rn "server/discover\|resultType\|cacheScope\|requestState\|subscriptions/listen" tests/protocol/
+```
+
+Expected: every row maps to at least one assertion. If a row has none, either add the test or remove the row — the document must not overclaim.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/PROTOCOL_COMPATIBILITY.md README.md
+git commit -m "docs: add MCP protocol compatibility matrix"
+```
+
+---
+
+## Deferred — deliberately out of scope for this plan
+
+These are real and worth doing; they are not in this plan because each needs its
+own design pass and none of them blocks the bridge. Recording them so they are
+tracked rather than forgotten.
+
+1. **`subscriptions/listen` server implementation.** Task 13 lowers the method
+   for downstream calls, but the hub does not yet *serve* a long-lived
+   subscription stream to modern clients. Needs a design decision on where the
+   stream lives in a horizontally-scaled deployment.
+2. **Tasks extension ↔ PAP bridge.** `io.modelcontextprotocol/tasks` maps closely
+   onto PAP's agent lifecycle: a long-running tool call becomes a provisioned
+   agent, and the task handle becomes the agent handle. `tasks/list` was removed
+   from the extension, which makes PAP's agent registry the natural inventory.
+   This is the largest differentiation opportunity in the release and deserves a
+   dedicated plan.
+3. **MCP Apps extension.** Server-rendered UI in sandboxed iframes. pluggedin-app
+   is already a React surface; hosting MCP Apps is a product decision first.
+4. **Durable handle store.** `HandleStore` is in-process. Sharing it across
+   instances (Redis or Postgres) is what actually unlocks the serverless/edge
+   deployment the stateless core makes possible.
+5. **OTel export.** Task 2 reads `traceparent`/`tracestate`/`baggage` from
+   `_meta`; nothing yet exports spans. Pairs with pluggedin-observability.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every major change in the 2026-07-28 changelog maps to a task:
+stateless core → 5, 11, 16; `server/discover` → 6, 12; removed sessions → 7, 16, 17;
+`subscriptions/listen` → 13 (lowering) and Deferred #1 (serving); removed `ping`/
+`logging/setLevel`/`roots/list_changed` → 1 (capability matrix), 2 (`logLevel`);
+tasks extension → Deferred #2; MRTR → 9; `resultType` → 9, 11, 13; removed SSE
+resumability → documented in 19 with the reasoning for not retrying; `extensions`
+field → 6; OTel `_meta` → 2; deterministic tool order → 8; `CacheableResult` → 8;
+resource-not-found renumbering → 3; `iss` validation → 18; `application_type` → 18;
+issuer-bound credentials → 18; JSON Schema loosening → not implemented (no
+validation of `inputSchema` keywords exists to loosen); error-code policy → 3;
+deprecations → 1, 19.
+
+**Gap accepted:** SEP-2106's JSON Schema loosening needs no code because the proxy
+does not currently constrain `inputSchema` keywords — there is nothing to relax.
+Noted rather than given a no-op task.
+
+**Placeholder scan.** No "TBD", no "add error handling", no "similar to Task N".
+Task 17 Step 1 is the one place that asks the implementer to read a file before
+writing the test — because the wrapper's constructor signature is not reproduced
+here — and it states exactly which three assertions must survive.
+
+**Type consistency.** `Revision`, `capabilitiesFor`, `Implementation`, `META_KEYS`,
+`ProtocolError`, `PROTOCOL_ERROR_CODES`, `HandleStore`, `InputRequest`,
+`InputResponse`, `InputRequiredResult`, `DownstreamProfile`, `CacheScope` are each
+defined once and referenced with the same names and shapes throughout.
+`normalizeResultType` and `isInputRequired` are defined in Task 9 and used in
+Tasks 11 and 14 with matching signatures. `lowerRequest`/`lowerResult` are defined
+in Task 13 and used in Task 14. `CLIENT_PROTOCOL_VERSION` vs
+`ADVERTISED_PROTOCOL_VERSION` are distinguished in Task 15 and used consistently
+in Tasks 15 and 16.


### PR DESCRIPTION
**Documentation only — no implementation.** This adds the implementation plan for MCP 2026-07-28 support. None of the 19 tasks are executed; `src/protocol/` does not exist yet.

## Why a plan and not code

The finding that shaped it: **no released SDK implements 2026-07-28.** `@modelcontextprotocol/sdk@1.30.0`, the newest on npm, still ships `LATEST_PROTOCOL_VERSION = '2025-11-25'`, with no `server/discover`, no top-level `resultType` and no MRTR. The only `input_required` string in it is `TaskStatusSchema` — the *old* experimental tasks design that SEP-2663 replaced.

So 2026-07-28 has to be hand-rolled, which is also the opportunity: a hub that bridges revisions while the official SDK lags has a head start that disappears once the SDK catches up.

## Architecture

Canonical internal representation is **2026-07-28** — the most explicit revision, since every request self-describes via `_meta` and carries no ambient session state. Any inbound revision is *lifted* into it; every outbound request is *lowered* onto whatever the target downstream server was discovered to speak. Because the canonical form is a superset, translation is lossless both ways, and the features deleted from the core (sampling, roots, logging, server-initiated requests) survive as proxy-side emulation rather than breaking.

## Scope

19 tasks across five phases, each with full TDD steps and real code — no placeholders:

- **Phase A (1–11)** — north side: revision registry, `_meta` keys, spec-reserved error codes, SDK pin, inbound revision detection, `server/discover`, server-minted handles replacing sessions, `CacheableResult` + deterministic tool ordering, MRTR, `Mcp-Method`/`x-mcp-header`, Express wiring
- **Phase B (12–14)** — south side: downstream revision probe (`server/discover` with `initialize` fallback), lowering, end-to-end bridge test
- **Phase C (15–17)** — pluggedin-app: the four hardcoded `2024-11-05` sites, stateless requests currently 400ing, confining `StreamableHTTPWrapper` to legacy revisions
- **Phase D (18)** — Client ID Metadata Documents, RFC 9207 `iss` validation, `application_type`
- **Phase E (19)** — compatibility matrix

Deliberate exclusions are listed with reasons at the end. The largest is the **Tasks extension ↔ PAP bridge**: `tasks/list` was removed from the extension, making task inventory the server's responsibility — which is what PAP's agent registry already provides. That is the biggest differentiation opportunity in this release, but it needs its own design pass and does not block the bridge.

## Relationship to what already merged

Task 4 pins the SDK to 1.30.0. #72 already did that, for an unrelated reason — the `@hono/node-server` 2.x override needed an SDK whose declared range admits it. Task 4 carries a note so the implementer verifies rather than re-applies.

The rest of Task 4 is still outstanding and is a live risk: [`src/constants.ts:31`](https://github.com/VeriTeknik/pluggedin-mcp/blob/main/src/constants.ts#L31) still derives `MCP_PROTOCOL_VERSION` from the SDK's `LATEST_PROTOCOL_VERSION`. Harmless while the SDK is pinned, but the moment someone restores a caret or bumps manually, the hub starts advertising a revision whose handshake it does not implement. The plan includes a deliberately-failing tripwire test for exactly that.

## A correction the security work forced

The plan originally said `npm install` and `git add package-lock.json`, and used `npm test`. All three were wrong: both repos are `pnpm@11.5.1` with `pnpm-lock.yaml`, and this repo's `test` script is a bare `vitest` that enters watch mode in a TTY and would hang an implementer. Fixed in the second commit, which also records that pluggedin-app already fails 204 tests on `main` (see VeriTeknik/pluggedin-app#173) so a task is judged by whether it moves that count.

## Summary by Sourcery

Add a detailed implementation plan document for achieving MCP 2026-07-28 compliance and protocol version bridging across pluggedin-mcp and pluggedin-app, without introducing any code changes.

Documentation:
- Document the architecture for a new protocol layer that canonicalizes requests to MCP 2026-07-28 and bridges between multiple MCP revisions.
- Outline phased tasks for implementing northbound and southbound protocol handling, including revision detection, error codes, MRTR, caching, and header semantics.
- Specify coordination work required in pluggedin-app to align protocol versions, support stateless requests, and limit legacy-only transports.
- Describe planned OAuth and issuer validation updates and a protocol compatibility matrix to communicate supported MCP revisions and behaviors.
- Record deferred items such as subscriptions/listen serving, tasks extension integration, durable handle storage, and observability export for future work.